### PR TITLE
Add EURIS IENC catalog

### DIFF
--- a/EURIS_IENC_Catalog.xml
+++ b/EURIS_IENC_Catalog.xml
@@ -1,0 +1,10422 @@
+﻿<?xml version='1.0' encoding='utf-8'?>
+<RncProductCatalogChartCatalogs>
+	<Header>
+		<title>EURIS IENC Charts</title>
+		<date_created>2024-09-02</date_created>
+		<time_created>08:51:48</time_created>
+		<date_valid>2024-09-02</date_valid>
+		<time_valid>08:51:48</time_valid>
+		<dt_valid>2024-09-02T08:51:48Z</dt_valid>
+		<ref_spec>Subset of NOAA Rnc Product Catalog Technical Specifications</ref_spec>
+		<ref_spec_vers>1.0</ref_spec_vers>
+		<s62AgencyCode>0</s62AgencyCode>
+	</Header>
+	<chart>
+		<number>2331356692</number>
+		<title>1H7D1700</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=a62a71a0-f8b0-4d22-8b98-003f55fc7a1d</zipfile_location>
+		<zipfile_datetime>20230712_063526</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-07-12T06:35:26Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2996770884</number>
+		<title>2P7D1114</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=5a35947f-b8c8-4979-9b98-004920ec020f</zipfile_location>
+		<zipfile_datetime>20230408_063536</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-08T06:35:36Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>563808212</number>
+		<title>4V5002DE</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=6f982b1c-1608-4c2b-b446-0060c90f7181</zipfile_location>
+		<zipfile_datetime>20201022_171704</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-22T17:17:04Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2545213185</number>
+		<title>1W7RHK01</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=071c5822-9bb6-44e1-9c93-0097e586e5f5</zipfile_location>
+		<zipfile_datetime>20210503_145617</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-03T14:56:17Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3529901265</number>
+		<title>2P7D1408</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=15b3c853-5f4a-4858-aeae-00abe0eb6350</zipfile_location>
+		<zipfile_datetime>20230408_063539</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-08T06:35:39Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>325512256</number>
+		<title>1H7D1540</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=022493f3-95a1-4e52-b85b-016c1bbcc3ba</zipfile_location>
+		<zipfile_datetime>20230712_063523</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-07-12T06:35:23Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1040935143</number>
+		<title>7V7BEVE1</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=f07f66cf-61db-482a-b4c6-0211747f1bd2</zipfile_location>
+		<zipfile_datetime>20210701_111429</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:14:29Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2725444779</number>
+		<title>2R71037S</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=bd3ba311-bef8-4d12-840f-02436e82f80f</zipfile_location>
+		<zipfile_datetime>20210126_112613</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-01-26T11:26:13Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4081589291</number>
+		<title>1W7RH200</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=2c6c6bc9-9613-4a77-a611-02a31a16b82e</zipfile_location>
+		<zipfile_datetime>20201022_171711</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-22T17:17:11Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>335691215</number>
+		<title>1W7ML140</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=6a9c9089-221b-4cb8-8daa-02d022bdf3fc</zipfile_location>
+		<zipfile_datetime>20210908_095530</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:30Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1606833352</number>
+		<title>1R7MA197</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=74de4eb8-7db6-49bf-abef-03017948cf64</zipfile_location>
+		<zipfile_datetime>20210903_115921</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T11:59:21Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2174316533</number>
+		<title>1H7TI480</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=0e29d6cb-7eb4-47ac-8cdd-031377f26b07</zipfile_location>
+		<zipfile_datetime>20211012_145500</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-10-12T14:55:00Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3694235086</number>
+		<title>1W7NE110</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=e8b2a469-b72d-4feb-b9f4-032a1db806b6</zipfile_location>
+		<zipfile_datetime>20210914_095427</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-14T09:54:27Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1573352850</number>
+		<title>2WBD1873</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=d1f48760-b4dc-46c5-a784-034a66a2ae4f</zipfile_location>
+		<zipfile_datetime>20240614_063710</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-06-14T06:37:10Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3272987840</number>
+		<title>2R70995A</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=18a660cd-4797-4bca-9fd8-03d96f94db28</zipfile_location>
+		<zipfile_datetime>20210126_112611</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-01-26T11:26:11Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1290617663</number>
+		<title>1H7D1460</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=181c4d9e-1575-438a-a9e6-0435ef50fffe</zipfile_location>
+		<zipfile_datetime>20230712_063521</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-07-12T06:35:21Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2200706266</number>
+		<title>1H7D1470</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=21062d23-c630-4e1d-9d7f-0476f4624241</zipfile_location>
+		<zipfile_datetime>20230712_063521</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-07-12T06:35:21Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2595606093</number>
+		<title>1W7HO080</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=a9363daa-45a8-4a66-9667-04a2eaa9d6a4</zipfile_location>
+		<zipfile_datetime>20201016_162828</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-16T16:28:28Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>436950338</number>
+		<title>7V7BZS01</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=973ad0fa-6a62-4c96-9759-051f78105444</zipfile_location>
+		<zipfile_datetime>20210701_111121</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:11:21Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1913915128</number>
+		<title>1W7DE005</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=bc4a665d-5420-4bfa-a936-05293f4f6777</zipfile_location>
+		<zipfile_datetime>20240227_063704</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:04Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3673132005</number>
+		<title>3R7D0617</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=6f588536-9c18-48f3-8b32-05482f0045b9</zipfile_location>
+		<zipfile_datetime>20240821_063616</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-21T06:36:16Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3023374510</number>
+		<title>7V7ALBK2</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=4efa3b57-4e4c-4155-8b74-055e5724556b</zipfile_location>
+		<zipfile_datetime>20210701_110745</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:07:45Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3208846629</number>
+		<title>1R7WK012</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=8d0c3094-4f98-4d12-ab32-056e2863ffc2</zipfile_location>
+		<zipfile_datetime>20210903_143856</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T14:38:56Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2710286925</number>
+		<title>1W7ML010</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=cc78e823-1827-4859-b91e-05fc014f1056</zipfile_location>
+		<zipfile_datetime>20210908_095526</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:26Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2698388246</number>
+		<title>1W7ML240</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=45d3213b-9c85-4a75-b961-0610c77cf9ac</zipfile_location>
+		<zipfile_datetime>20210908_095534</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:34Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1128588232</number>
+		<title>7V7DTS01</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=e6bab511-22ce-46d5-8ba0-06f79a77814a</zipfile_location>
+		<zipfile_datetime>20210701_111257</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:12:57Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2886465532</number>
+		<title>2WBD2023</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=89ef39cc-87e6-4902-81f2-06fdb4b3778d</zipfile_location>
+		<zipfile_datetime>20240731_063654</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-07-31T06:36:54Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3435212812</number>
+		<title>1W7DE017</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=caf32b7b-a060-42a8-aad8-074625c7a413</zipfile_location>
+		<zipfile_datetime>20230413_063524</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-13T06:35:24Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>102921006</number>
+		<title>1W7RH700</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=cf5123b8-7820-4f50-985e-076e959449f4</zipfile_location>
+		<zipfile_datetime>20210503_145644</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-03T14:56:44Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1668838833</number>
+		<title>2WBD2180</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=febe6374-d894-4993-9329-07a6c67c68ba</zipfile_location>
+		<zipfile_datetime>20240131_063610</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-01-31T06:36:10Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1863224183</number>
+		<title>1W7MD140</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=1e4159bc-ffbd-4ce3-8c66-07c6d6880395</zipfile_location>
+		<zipfile_datetime>20210512_145225</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-12T14:52:25Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2371582351</number>
+		<title>1W7DE000</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=e27d14fe-80d0-4ad8-9226-07dd03eaf6eb</zipfile_location>
+		<zipfile_datetime>20210503_145609</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-03T14:56:09Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4253270343</number>
+		<title>2D7D1752</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=9db2b41a-c39a-4ada-8cf6-07f78539be2c</zipfile_location>
+		<zipfile_datetime>20210908_095509</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:09Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3282037711</number>
+		<title>1W7RH170</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=0db979c0-343d-4eb9-833e-08177861e74a</zipfile_location>
+		<zipfile_datetime>20201022_171711</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-22T17:17:11Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2205224650</number>
+		<title>7V7BOSC1</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=dcbf4ded-45e9-4dec-9a26-0821da198696</zipfile_location>
+		<zipfile_datetime>20210701_111119</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:11:19Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2360696678</number>
+		<title>1W7DE004</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=670bf4ac-0a95-473d-9265-084072845f9b</zipfile_location>
+		<zipfile_datetime>20230413_063523</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-13T06:35:23Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3688999455</number>
+		<title>3B7D0448</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=ea90e452-863e-4537-bc07-0866d7d40176</zipfile_location>
+		<zipfile_datetime>20240829_063722</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-29T06:37:22Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3988478626</number>
+		<title>3R7DCC05</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=bea4cc3d-2708-4eaf-b9ef-0884e22aaaf5</zipfile_location>
+		<zipfile_datetime>20201016_162814</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-16T16:28:14Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1448054431</number>
+		<title>1W7D2400</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=d67b9873-2213-4692-93c1-08aab6236fcd</zipfile_location>
+		<zipfile_datetime>20220611_063524</zipfile_datetime>
+		<zipfile_datetime_iso8601>2022-06-11T06:35:24Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4157606508</number>
+		<title>1W7SL055</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=e7dea871-f5aa-4d7c-8992-08ac715117c2</zipfile_location>
+		<zipfile_datetime>20231011_063505</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-10-11T06:35:05Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2237190293</number>
+		<title>1W7OD590</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=d6633503-9e49-4d01-aa99-08e229f480b1</zipfile_location>
+		<zipfile_datetime>20210205_120408</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-02-05T12:04:08Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2673197630</number>
+		<title>2W7D1930</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=0ca55f26-4f26-4b2d-b8a5-08e44745c63f</zipfile_location>
+		<zipfile_datetime>20240628_063619</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-06-28T06:36:19Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4212554737</number>
+		<title>1W7D2370</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=ff8cfbf7-0fe1-4fab-b191-099b9745430f</zipfile_location>
+		<zipfile_datetime>20220611_063524</zipfile_datetime>
+		<zipfile_datetime_iso8601>2022-06-11T06:35:24Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3033723648</number>
+		<title>1W7PHV20</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=d5a9af15-a1bf-450a-a5dd-09cb1e428294</zipfile_location>
+		<zipfile_datetime>20230804_063501</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-08-04T06:35:01Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>791866583</number>
+		<title>1W7NE190</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=9ca4c7a9-4ad6-49ab-a842-0a1f700de7e5</zipfile_location>
+		<zipfile_datetime>20210914_095429</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-14T09:54:29Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2693854787</number>
+		<title>9D7VL017</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=f788ed6f-2c57-4f12-8abf-0a2caa8d889c</zipfile_location>
+		<zipfile_datetime>20230331_063531</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-03-31T06:35:31Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2334292859</number>
+		<title>1W7DE011</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=4de0d4f9-d83b-47e5-aa79-0a324db56dbd</zipfile_location>
+		<zipfile_datetime>20240227_063706</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:06Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1237726136</number>
+		<title>1W7D2270</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=75ad7187-aa1f-496f-a6d3-0a3b86ec17ea</zipfile_location>
+		<zipfile_datetime>20220611_063523</zipfile_datetime>
+		<zipfile_datetime_iso8601>2022-06-11T06:35:23Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2061614256</number>
+		<title>5C7D1379</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=04dda89d-84b7-4a24-ad4b-0a613c861178</zipfile_location>
+		<zipfile_datetime>20231109_102532</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-11-09T10:25:32Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>777689166</number>
+		<title>1R7LE976</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=a1bcbe8b-a0de-4cfa-9cea-0a7299a77f17</zipfile_location>
+		<zipfile_datetime>20210903_140554</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T14:05:54Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3894723930</number>
+		<title>1W7MA080</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=6670e4ee-a035-4999-97b1-0a80c34b2781</zipfile_location>
+		<zipfile_datetime>20210512_145210</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-12T14:52:10Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>840080041</number>
+		<title>1W7SL035</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=b09d3bc6-d1ba-498f-a822-0adb8af8207f</zipfile_location>
+		<zipfile_datetime>20231011_063505</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-10-11T06:35:05Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1208173093</number>
+		<title>4V5011DE</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=6e1926ff-be2b-4029-8df5-0b3250b8b566</zipfile_location>
+		<zipfile_datetime>20201022_171705</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-22T17:17:05Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1390282652</number>
+		<title>1H7TI380</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=631c341c-6c8c-447e-a65a-0b5432a7be7e</zipfile_location>
+		<zipfile_datetime>20211012_145457</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-10-12T14:54:57Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3162515360</number>
+		<title>1R7BE962</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=0fb47ab7-2e6d-4975-a380-0be0ef3fa7f5</zipfile_location>
+		<zipfile_datetime>20210903_154702</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T15:47:02Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>260785983</number>
+		<title>7V7KBKO2</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=1b7a21be-69e4-40b3-b7da-0c49f222f199</zipfile_location>
+		<zipfile_datetime>20210701_111301</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:13:01Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4063026884</number>
+		<title>1W7MO200</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=496ce91b-7ef9-4ebd-b45a-0c832befb96a</zipfile_location>
+		<zipfile_datetime>20210908_095522</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:22Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4175016833</number>
+		<title>1R7MA006</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=b3282cbb-ea9a-4267-81ba-0ca09be7a1b3</zipfile_location>
+		<zipfile_datetime>20210607_103507</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-06-07T10:35:07Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>635741002</number>
+		<title>2P7D1186</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=510e5cc5-0aed-4729-9196-0ca16aa334db</zipfile_location>
+		<zipfile_datetime>20230408_063536</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-08T06:35:36Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1893021175</number>
+		<title>3R7D0691</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=13f03d93-f9d6-449e-8912-0cac30ff9466</zipfile_location>
+		<zipfile_datetime>20240821_063618</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-21T06:36:18Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4193717344</number>
+		<title>1W7MA360</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=060e5e8c-2d2f-4fb7-91ac-0cddc03d6e9e</zipfile_location>
+		<zipfile_datetime>20210512_145218</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-12T14:52:18Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>794084448</number>
+		<title>9D7EL870</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=eb32c7fc-0943-422d-948a-0cee3fcf2c91</zipfile_location>
+		<zipfile_datetime>20230331_063529</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-03-31T06:35:29Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1676156793</number>
+		<title>1W7NE170</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=dbeff489-a125-4261-8bac-0d09e840f623</zipfile_location>
+		<zipfile_datetime>20210914_095428</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-14T09:54:28Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2960181832</number>
+		<title>4V7SEI17</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=e7cd8c29-d8cd-4f53-9ef8-0d1692fb4fae</zipfile_location>
+		<zipfile_datetime>20240409_164713</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-04-09T16:47:13Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3141633018</number>
+		<title>1W7ML110</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=2aaeae9c-5dae-4e52-a5ea-0d2d085c5fdf</zipfile_location>
+		<zipfile_datetime>20210908_095529</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:29Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2404893710</number>
+		<title>2WBD1912</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=6a615292-1504-4136-b78b-0d35668c020a</zipfile_location>
+		<zipfile_datetime>20240614_063724</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-06-14T06:37:24Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4106963618</number>
+		<title>1W7UH080</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=95331f10-b190-47fb-a1cc-0d41e391a977</zipfile_location>
+		<zipfile_datetime>20231011_063504</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-10-11T06:35:04Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>313915611</number>
+		<title>1R7WA867</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=800d63fe-4b4e-4ef8-ae4e-0d6aca370689</zipfile_location>
+		<zipfile_datetime>20210903_144227</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T14:42:27Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2177928546</number>
+		<title>2P7D1241</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=abf157df-2ebd-4822-9337-0d8d006e4375</zipfile_location>
+		<zipfile_datetime>20230408_063537</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-08T06:35:37Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3018283108</number>
+		<title>2W7D1920</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=ab5957f5-8160-4e48-93cd-0dd440a62e27</zipfile_location>
+		<zipfile_datetime>20230930_063730</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-09-30T06:37:30Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>440021067</number>
+		<title>1W7MA070</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=2ce6fa65-f9cb-46fa-91f7-0e1e8452bcb8</zipfile_location>
+		<zipfile_datetime>20210512_145210</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-12T14:52:10Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1066783771</number>
+		<title>7V7LEIE1</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=3cf5ac61-bb65-4f55-a2d7-0e26da79e367</zipfile_location>
+		<zipfile_datetime>20210701_112113</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:21:13Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>246942187</number>
+		<title>1W7SKH00</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=35b3403c-2e22-472a-a019-0e7408854622</zipfile_location>
+		<zipfile_datetime>20210930_095437</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-30T09:54:37Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4248503052</number>
+		<title>3R7D1054</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=6e2fa6a6-894d-486c-91b5-0eac0fee04cd</zipfile_location>
+		<zipfile_datetime>20201209_103453</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-12-09T10:34:53Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2466928656</number>
+		<title>7V7MOER1</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=865bc7ce-fd78-4c80-8784-0ed9508bdab7</zipfile_location>
+		<zipfile_datetime>20210701_112116</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:21:16Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>691878789</number>
+		<title>2P7D0866</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=a396ffb4-8fac-4e34-8405-0ef7e7658e39</zipfile_location>
+		<zipfile_datetime>20230408_063533</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-08T06:35:33Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>818966408</number>
+		<title>1W7EL380</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=a8e45492-131c-402a-a438-0f0c2de10e36</zipfile_location>
+		<zipfile_datetime>20240227_063722</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:22Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1851346217</number>
+		<title>1R7SK001</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=fc95f736-385f-4d30-8188-0fc7518143c0</zipfile_location>
+		<zipfile_datetime>20210903_151448</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T15:14:48Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>300284764</number>
+		<title>3R7BM006</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=33750248-76e0-49b8-9487-1074acd6fa8d</zipfile_location>
+		<zipfile_datetime>20220326_095419</zipfile_datetime>
+		<zipfile_datetime_iso8601>2022-03-26T09:54:19Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2852077295</number>
+		<title>1W7SL045</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=8c9b30cf-a4b6-491a-b582-10a11d35f2f1</zipfile_location>
+		<zipfile_datetime>20231011_063505</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-10-11T06:35:05Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1688023081</number>
+		<title>1W7MO150</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=340ab993-10fb-4597-9e54-10a363110862</zipfile_location>
+		<zipfile_datetime>20210908_095521</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:21Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1143034857</number>
+		<title>2P7D1013</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=30c0d615-3042-40f3-8ee8-10ec06db400e</zipfile_location>
+		<zipfile_datetime>20230408_063535</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-08T06:35:35Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>402907501</number>
+		<title>1W7MA060</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=1e2dc466-8d49-4319-8bac-1116cfb649f5</zipfile_location>
+		<zipfile_datetime>20210512_145210</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-12T14:52:10Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>401848478</number>
+		<title>1W7BRW02</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=05d55bf6-03f8-47ff-9838-1169c1239890</zipfile_location>
+		<zipfile_datetime>20230804_063501</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-08-04T06:35:01Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1369136551</number>
+		<title>1W7UH090</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=248ee4e2-876a-4f2a-96e4-117533369760</zipfile_location>
+		<zipfile_datetime>20230804_063459</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-08-04T06:34:59Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1054629148</number>
+		<title>1W7MO130</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=e0920183-ca78-4859-a1b3-1230d49cd8f9</zipfile_location>
+		<zipfile_datetime>20210908_095518</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:18Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4168392153</number>
+		<title>3R7D0219</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=d1b82e08-2aea-4cec-bae4-125c3867fe6e</zipfile_location>
+		<zipfile_datetime>20240613_063559</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-06-13T06:35:59Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1838749387</number>
+		<title>1H7TI250</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=4378d636-c508-416a-85ff-12b31ce31448</zipfile_location>
+		<zipfile_datetime>20211012_145454</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-10-12T14:54:54Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3595436515</number>
+		<title>1R7YM017</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=317b9618-df0e-46e8-adf5-12b5f460bff9</zipfile_location>
+		<zipfile_datetime>20210903_124817</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T12:48:17Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2583780071</number>
+		<title>4V5MOS07</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=b8bf7031-4fdc-49ba-98ee-12d45b0172bb</zipfile_location>
+		<zipfile_datetime>20221201_181932</zipfile_datetime>
+		<zipfile_datetime_iso8601>2022-12-01T18:19:32Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4199377200</number>
+		<title>1R7WZ005</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=6568f8db-77e1-4d03-9c1d-12f810645836</zipfile_location>
+		<zipfile_datetime>20210903_105738</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T10:57:38Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>281712823</number>
+		<title>7V7ALBK5</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=d205d812-88c0-413d-a173-135cc53e44fd</zipfile_location>
+		<zipfile_datetime>20210701_110746</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:07:46Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1647239319</number>
+		<title>1H7TI320</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=cde78b0c-7a56-4bff-8a94-1365a6520c46</zipfile_location>
+		<zipfile_datetime>20211012_145455</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-10-12T14:54:55Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2273137804</number>
+		<title>1H7D1590</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=a71a3508-9d9d-4a5b-a3de-136fee97a7bd</zipfile_location>
+		<zipfile_datetime>20230712_063524</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-07-12T06:35:24Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>846402715</number>
+		<title>2WBD1893</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=1ea7b8d3-30da-41d9-bbcd-139a7cc60436</zipfile_location>
+		<zipfile_datetime>20240614_063719</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-06-14T06:37:19Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>437674585</number>
+		<title>1H7D1540</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=607a8106-adfa-4612-a7ae-13d142f3efe8</zipfile_location>
+		<zipfile_datetime>20210722_145801</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-22T14:58:01Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>517157183</number>
+		<title>3B7D0577</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=9066342f-abe4-4fbb-90fe-13da70f98997</zipfile_location>
+		<zipfile_datetime>20240829_063726</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-29T06:37:26Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>725060339</number>
+		<title>7V7ALBK3</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=e728e408-f8ac-47e3-bde0-13fc9fc797fb</zipfile_location>
+		<zipfile_datetime>20210701_110745</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:07:45Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2026185116</number>
+		<title>3R7D94HM</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=36dd769c-17d2-46b8-a8e8-142dfa59f9a7</zipfile_location>
+		<zipfile_datetime>20240613_063602</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-06-13T06:36:02Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3874537863</number>
+		<title>3R7D0819</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=2eb8d47d-ade3-461b-a3c8-14a4fef23679</zipfile_location>
+		<zipfile_datetime>20240821_063622</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-21T06:36:22Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3016852288</number>
+		<title>7V7KBKO1</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=62f6f56d-884a-4801-aa87-14adad630363</zipfile_location>
+		<zipfile_datetime>20210701_111301</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:13:01Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3314578712</number>
+		<title>2P7SA149</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=ffb743b7-6a1e-4d83-9eaf-14ae46addf52</zipfile_location>
+		<zipfile_datetime>20230413_063522</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-13T06:35:22Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4062855678</number>
+		<title>1W7D2310</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=d2b4c9fd-0b66-43a5-b06e-153ba8ee44d9</zipfile_location>
+		<zipfile_datetime>20220611_063523</zipfile_datetime>
+		<zipfile_datetime_iso8601>2022-06-11T06:35:23Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3107629202</number>
+		<title>1W7WDK05</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=d3ec07d1-9d47-46b5-be8f-157374ab8736</zipfile_location>
+		<zipfile_datetime>20210503_145618</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-03T14:56:18Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2947140825</number>
+		<title>1W7EL420</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=21a1f21d-8ffc-4862-a462-15d56c0338e4</zipfile_location>
+		<zipfile_datetime>20240227_063722</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:22Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>663804316</number>
+		<title>1W7RH750</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=15132c65-8f8f-4e1a-84c6-161806c7a3fa</zipfile_location>
+		<zipfile_datetime>20210503_145645</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-03T14:56:45Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>450636497</number>
+		<title>4V5GA040</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=b034bf3f-b294-4aca-b4ea-1654a4f11ea3</zipfile_location>
+		<zipfile_datetime>20201022_171706</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-22T17:17:06Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1847920597</number>
+		<title>1W7ML220</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=b4b3f6b2-6ba5-44bc-b60b-1679e804d887</zipfile_location>
+		<zipfile_datetime>20210908_095532</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:32Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3974155664</number>
+		<title>1W7NE130</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=c9bc6a20-cf7d-4c43-8bfa-16bed5cdd3fe</zipfile_location>
+		<zipfile_datetime>20220125_095422</zipfile_datetime>
+		<zipfile_datetime_iso8601>2022-01-25T09:54:22Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2438295816</number>
+		<title>1W7RH810</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=139f0542-01a7-4f85-ba2b-16f70fbdb66b</zipfile_location>
+		<zipfile_datetime>20210503_145646</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-03T14:56:46Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4289669484</number>
+		<title>2P7SA202</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=30dfea97-e1eb-47e6-aeee-171c579226f2</zipfile_location>
+		<zipfile_datetime>20230413_063522</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-13T06:35:22Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1720477830</number>
+		<title>7V7ALBK8</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=113d5f69-14b0-4ca0-85e3-174692fadfb9</zipfile_location>
+		<zipfile_datetime>20210701_110747</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:07:47Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2730686708</number>
+		<title>2W7D1900</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=7930d3f7-4dbc-4209-9792-174c891b0e5a</zipfile_location>
+		<zipfile_datetime>20240529_063630</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-05-29T06:36:30Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1082166097</number>
+		<title>4V5MOS05</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=fb43d1a3-e7b3-4f5d-8196-17543ec21953</zipfile_location>
+		<zipfile_datetime>20221201_181837</zipfile_datetime>
+		<zipfile_datetime_iso8601>2022-12-01T18:18:37Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3781693133</number>
+		<title>2P7D1094</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=1dd153da-13a2-46ac-89eb-17b9869423f9</zipfile_location>
+		<zipfile_datetime>20230408_063535</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-08T06:35:35Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2419055349</number>
+		<title>1W7EL160</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=494a025b-62c3-4ec8-ad81-17c637a3656c</zipfile_location>
+		<zipfile_datetime>20240227_063718</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:18Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3524767520</number>
+		<title>1W7EL460</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=43d1ca7a-c951-437f-a9ef-17f2ddde9fc4</zipfile_location>
+		<zipfile_datetime>20240227_063723</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:23Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1259157639</number>
+		<title>3R7D0072</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=808540ac-d350-4125-b670-181540fab620</zipfile_location>
+		<zipfile_datetime>20240824_063611</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-24T06:36:11Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1660515306</number>
+		<title>1W7MD170</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=586813da-c16b-4db5-848f-184d0b982dc7</zipfile_location>
+		<zipfile_datetime>20210512_145225</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-12T14:52:25Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4278989624</number>
+		<title>4V7SEI07</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=d3d12ccc-81c3-4758-a5fa-1855d8e7e4ee</zipfile_location>
+		<zipfile_datetime>20240409_163749</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-04-09T16:37:49Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1641256189</number>
+		<title>9D7EL910</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=6fcb22b9-1d32-4a8f-9df7-188947373c9e</zipfile_location>
+		<zipfile_datetime>20230331_063530</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-03-31T06:35:30Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1016668427</number>
+		<title>2WBDHKRE</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=22f46a58-c94f-4ae1-81db-189bedb6b2d1</zipfile_location>
+		<zipfile_datetime>20240731_063657</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-07-31T06:36:57Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1944183751</number>
+		<title>3B7D0397</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=62c74f08-4aab-4e42-8a00-19899686d736</zipfile_location>
+		<zipfile_datetime>20240829_063721</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-29T06:37:21Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2168075532</number>
+		<title>1R7DK980</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=61a18254-4f5c-4f62-8d27-19f86ba200e3</zipfile_location>
+		<zipfile_datetime>20210903_164826</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T16:48:26Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3790400681</number>
+		<title>1W7EL430</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=2a57ec35-4d3c-486e-8a0a-1a4624facc03</zipfile_location>
+		<zipfile_datetime>20240227_063723</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:23Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1949553959</number>
+		<title>2WBD2150</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=0b9fce85-b8f3-43c1-a769-1b6aa5bb2ba6</zipfile_location>
+		<zipfile_datetime>20231025_063504</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-10-25T06:35:04Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3924516351</number>
+		<title>4V7SEI02</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=a629fdcc-e958-4c2e-a43d-1baadbeb1d1f</zipfile_location>
+		<zipfile_datetime>20240409_163839</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-04-09T16:38:39Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1415699340</number>
+		<title>2WBDHLTH</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=d12d8b83-4c70-4d8a-bb45-1bc3da34e853</zipfile_location>
+		<zipfile_datetime>20240830_063636</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-30T06:36:36Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>237998034</number>
+		<title>1W7WE280</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=922815ea-7bef-4d35-b323-1bcea4163857</zipfile_location>
+		<zipfile_datetime>20210908_095539</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:39Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>135948262</number>
+		<title>1W7EL490</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=4ba58cee-aa7a-442f-a572-1be73a6fa46e</zipfile_location>
+		<zipfile_datetime>20240227_063724</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:24Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>315152213</number>
+		<title>1H7D1550</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=13ec36dd-6ebe-472d-9f5d-1c45f37c8d92</zipfile_location>
+		<zipfile_datetime>20230712_063523</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-07-12T06:35:23Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2621053637</number>
+		<title>2W7D2020</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=fcac6ff6-ad29-4b99-b515-1c6a971c4704</zipfile_location>
+		<zipfile_datetime>20240628_063620</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-06-28T06:36:20Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2765769443</number>
+		<title>1R7NK008</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=e27eaa3e-ebe7-447c-9d1c-1d20c428b635</zipfile_location>
+		<zipfile_datetime>20210903_150322</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T15:03:22Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>119935607</number>
+		<title>1R7WZ004</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=88f66a1c-9cb5-4d58-8b9a-1dab03382121</zipfile_location>
+		<zipfile_datetime>20210903_105622</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T10:56:22Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>537313169</number>
+		<title>2R71016N</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=897502fe-75df-4fb9-b486-1dfd6bdd2ff1</zipfile_location>
+		<zipfile_datetime>20210126_112612</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-01-26T11:26:12Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2469507722</number>
+		<title>1W7MO040</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=7698cfe5-0fdc-4858-8343-1e5de6a7b03c</zipfile_location>
+		<zipfile_datetime>20210908_095515</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:15Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2920241796</number>
+		<title>1W7SKO00</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=80340e8f-9b93-4cf9-8b2b-1e6ba5df9e46</zipfile_location>
+		<zipfile_datetime>20210908_095536</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:36Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3792289406</number>
+		<title>1W7ML200</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=7cb10988-88f0-479a-935f-1ebeda95f517</zipfile_location>
+		<zipfile_datetime>20210908_095531</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:31Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>343709163</number>
+		<title>1W7EL200</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=d9eda286-3c76-4a84-afe8-1ebf0e2bb624</zipfile_location>
+		<zipfile_datetime>20240227_063718</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:18Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2163121977</number>
+		<title>2W7D2080</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=2c086958-2b56-4a1b-8e96-1f765720d67e</zipfile_location>
+		<zipfile_datetime>20230930_063649</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-09-30T06:36:49Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3106650721</number>
+		<title>7V7BOSC5</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=025ec27b-7ac0-4496-a052-1fb8c6a1a1ba</zipfile_location>
+		<zipfile_datetime>20210701_111121</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:11:21Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2516636598</number>
+		<title>1W7TEK10</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=7508338a-6bd1-42d5-a88d-1fedbc29ae8c</zipfile_location>
+		<zipfile_datetime>20230126_063503</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-01-26T06:35:03Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1993405831</number>
+		<title>1H7TI610</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=22697722-3099-4666-b360-201f61b90e4f</zipfile_location>
+		<zipfile_datetime>20211012_145504</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-10-12T14:55:04Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1886513361</number>
+		<title>1W7RH780</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=67a8e477-cef2-42f7-a2a8-2023d6fce328</zipfile_location>
+		<zipfile_datetime>20210503_145645</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-03T14:56:45Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>920218086</number>
+		<title>2WBD2162</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=6857a09e-ec93-4f08-b570-20368e55130c</zipfile_location>
+		<zipfile_datetime>20240131_063609</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-01-31T06:36:09Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1400336591</number>
+		<title>1R7NR890</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=c6b331e8-0ef3-4b02-8a68-20b8fafd3127</zipfile_location>
+		<zipfile_datetime>20210903_152129</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T15:21:29Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3185081875</number>
+		<title>1W7SR000</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=0ef6c80a-c64a-400d-b06c-20fa9b00c3e7</zipfile_location>
+		<zipfile_datetime>20210908_095524</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:24Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1174715187</number>
+		<title>BE7EV001</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=1cfa61b1-34e1-4017-831e-217b6492c13a</zipfile_location>
+		<zipfile_datetime>20240820_112953</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-20T11:29:53Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2897714881</number>
+		<title>2P7D1302</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=41c0a48b-e32e-49ff-bbfc-21ce0d0a7aaa</zipfile_location>
+		<zipfile_datetime>20230408_063538</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-08T06:35:38Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>53947628</number>
+		<title>1R7WV079</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=693984e6-4cf6-4bfd-90a5-21ebb4119038</zipfile_location>
+		<zipfile_datetime>20210903_143241</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T14:32:41Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>685213762</number>
+		<title>1W7RH340</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=2919a870-da12-4032-882b-21fc95c86311</zipfile_location>
+		<zipfile_datetime>20240227_063708</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:08Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1573672700</number>
+		<title>BE7GT017</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=1251e3f4-3cb9-4af0-81b4-22206eeff5c0</zipfile_location>
+		<zipfile_datetime>20240517_091309</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-05-17T09:13:09Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1306104637</number>
+		<title>1W7RH640</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=60a52878-c3ff-4cac-b8b8-2242b772ff54</zipfile_location>
+		<zipfile_datetime>20210503_145643</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-03T14:56:43Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3732779646</number>
+		<title>7V7RGEN1</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=5b9e18a8-7e90-482f-8306-224609e58206</zipfile_location>
+		<zipfile_datetime>20210701_112117</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:21:17Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2006759202</number>
+		<title>2P7D1175</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=ee698f52-22f0-4386-ba4d-22634b6c4a0e</zipfile_location>
+		<zipfile_datetime>20230408_063540</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-08T06:35:40Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2041003572</number>
+		<title>3R7D1009</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=21fd98d2-6fe8-4d68-82d3-229f75605560</zipfile_location>
+		<zipfile_datetime>20201209_103453</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-12-09T10:34:53Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>369469472</number>
+		<title>1W7UH030</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=682da9aa-17da-409c-80c2-22a03f970165</zipfile_location>
+		<zipfile_datetime>20230804_063502</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-08-04T06:35:02Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2119801731</number>
+		<title>3R7D0027</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=d4d03473-94d4-4535-832e-22b63ae8b460</zipfile_location>
+		<zipfile_datetime>20240613_063601</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-06-13T06:36:01Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4203534372</number>
+		<title>2W7D2190</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=03d0336c-e62e-45f3-8c5a-22e47adfff4d</zipfile_location>
+		<zipfile_datetime>20230930_063731</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-09-30T06:37:31Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2198977822</number>
+		<title>1W7RH770</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=3c42788e-1c40-46c4-82db-236bb9507158</zipfile_location>
+		<zipfile_datetime>20240227_063714</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:14Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2777456552</number>
+		<title>4V7SEI08</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=7b6d03ce-0fa5-4f23-af42-23a6733c4d27</zipfile_location>
+		<zipfile_datetime>20240409_163914</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-04-09T16:39:14Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2629581434</number>
+		<title>1H7D1560</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=c41b5d5d-9a7a-4d12-bff7-23b8e132774b</zipfile_location>
+		<zipfile_datetime>20240507_063838</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-05-07T06:38:38Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3645616869</number>
+		<title>1H7TI190</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=cdd7dc9a-b18d-4695-8c13-23bc4091e9ce</zipfile_location>
+		<zipfile_datetime>20211012_145450</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-10-12T14:54:50Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>692771269</number>
+		<title>3R7SFG05</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=4e24d68b-aa51-4962-86ec-23cf4a5d5922</zipfile_location>
+		<zipfile_datetime>20201016_162825</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-16T16:28:25Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2804732539</number>
+		<title>1W7KK002</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=bb22714d-6e4f-4b4c-8f20-2498d7b24bc4</zipfile_location>
+		<zipfile_datetime>20240227_063707</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:07Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2598028078</number>
+		<title>7V7DEND2</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=1952f26f-d14f-46fa-bed0-24c070a50c6b</zipfile_location>
+		<zipfile_datetime>20210701_111123</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:11:23Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1859968137</number>
+		<title>4V7SEI12</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=d9b168e7-9abb-4d3e-9c5d-25184443a9d4</zipfile_location>
+		<zipfile_datetime>20240409_164024</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-04-09T16:40:24Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2065114882</number>
+		<title>4V5MOS10</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=500c41d1-7581-4819-86e5-25217e74b100</zipfile_location>
+		<zipfile_datetime>20221201_182048</zipfile_datetime>
+		<zipfile_datetime_iso8601>2022-12-01T18:20:48Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3792789366</number>
+		<title>7V7ZWV03</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=6a1d6053-cfef-447b-adfa-259687f6f13b</zipfile_location>
+		<zipfile_datetime>20210701_112122</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:21:22Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1606617079</number>
+		<title>1H7TI520</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=04ee7156-71a1-4abb-a3b9-2597f16ef51d</zipfile_location>
+		<zipfile_datetime>20211012_145501</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-10-12T14:55:01Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2591417149</number>
+		<title>1W7NE060</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=d2379453-4db7-4167-9eb2-259e80815d19</zipfile_location>
+		<zipfile_datetime>20210914_095424</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-14T09:54:24Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>488212768</number>
+		<title>1W7RH540</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=3fe2993a-34a9-4121-92a3-259ec4a7210a</zipfile_location>
+		<zipfile_datetime>20240227_063712</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:12Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>209249480</number>
+		<title>1W7D2380</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=9bd15179-3dee-4288-a37f-25ae085ac6e7</zipfile_location>
+		<zipfile_datetime>20220611_063524</zipfile_datetime>
+		<zipfile_datetime_iso8601>2022-06-11T06:35:24Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1157895434</number>
+		<title>3R7D0826</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=d0d51b31-272f-4c39-891a-25bff92f0c94</zipfile_location>
+		<zipfile_datetime>20240821_063623</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-21T06:36:23Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2623316705</number>
+		<title>2W7D1890</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=3dd54296-d7ef-4178-ab29-25c2d4aec543</zipfile_location>
+		<zipfile_datetime>20240830_063630</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-30T06:36:30Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>322012579</number>
+		<title>1W7D2210</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=ac490666-a7cf-4c15-bb65-25cec3979d31</zipfile_location>
+		<zipfile_datetime>20220730_063457</zipfile_datetime>
+		<zipfile_datetime_iso8601>2022-07-30T06:34:57Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2150613179</number>
+		<title>BE8NIE01</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=58929fc2-94ce-438e-994f-25d40da6f58c</zipfile_location>
+		<zipfile_datetime>20240820_112925</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-20T11:29:25Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1644712404</number>
+		<title>1W7EL300</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=9b2b75da-f868-4c9f-aed3-25d95386f7a3</zipfile_location>
+		<zipfile_datetime>20240227_063720</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:20Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1638053014</number>
+		<title>1W7SR010</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=a36b6266-7173-4bde-aaab-25dd4f699f8e</zipfile_location>
+		<zipfile_datetime>20210908_095524</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:24Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>401958678</number>
+		<title>1W7MO180</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=289fa6b5-21ae-4f35-87fa-25e26362986b</zipfile_location>
+		<zipfile_datetime>20210908_095522</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:22Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4264806100</number>
+		<title>1H7D1723</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=947d10aa-8ea4-4e46-986d-25e689882605</zipfile_location>
+		<zipfile_datetime>20230712_063526</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-07-12T06:35:26Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2406183067</number>
+		<title>1W7D2300</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=880a81e6-2948-4e80-8434-25f3d9a6f0e6</zipfile_location>
+		<zipfile_datetime>20220611_063523</zipfile_datetime>
+		<zipfile_datetime_iso8601>2022-06-11T06:35:23Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1613173409</number>
+		<title>1W7MO080</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=2c6f6d88-21a3-4d8c-a565-25fefa27ec07</zipfile_location>
+		<zipfile_datetime>20210908_095516</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:16Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>802615252</number>
+		<title>2WBD1914</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=6ddee4f9-829a-47d6-8eac-2635a49024e1</zipfile_location>
+		<zipfile_datetime>20240614_063725</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-06-14T06:37:25Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2607025936</number>
+		<title>7V7ALEI1</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=6e7b68d4-b4d9-4189-bed2-263c538c3e48</zipfile_location>
+		<zipfile_datetime>20210701_110749</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:07:49Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1821777635</number>
+		<title>3R7D0906</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=a5513725-deca-4032-9655-2661a1089bb9</zipfile_location>
+		<zipfile_datetime>20201209_103451</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-12-09T10:34:51Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3252007219</number>
+		<title>7V7ALB11</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=939ae58f-8f4b-4fae-a954-266b6fe5888a</zipfile_location>
+		<zipfile_datetime>20210701_110743</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:07:43Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3619565381</number>
+		<title>7V7DEND3</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=396e1935-3200-4c6e-878a-267bba384360</zipfile_location>
+		<zipfile_datetime>20210701_111124</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:11:24Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1278906888</number>
+		<title>1W7WDK00</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=0b0e48b4-352f-49fa-ac4a-26a0a5b46299</zipfile_location>
+		<zipfile_datetime>20240227_063707</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:07Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2778248850</number>
+		<title>1W7EL530</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=1e1bdbed-4844-4ee6-917e-26a1bf500557</zipfile_location>
+		<zipfile_datetime>20230207_063519</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-02-07T06:35:19Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1998399738</number>
+		<title>1W7MD060</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=e36fa626-0ea3-4d9c-8a43-26e04b198519</zipfile_location>
+		<zipfile_datetime>20210512_145220</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-12T14:52:20Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2412779975</number>
+		<title>5C7D1389</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=b84d9250-fedb-4928-9cce-2728f2b52d2f</zipfile_location>
+		<zipfile_datetime>20231109_102658</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-11-09T10:26:58Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3898070437</number>
+		<title>7V7DEND4</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=c3fbb9ea-87d5-403d-867b-27421ae889bb</zipfile_location>
+		<zipfile_datetime>20210701_111125</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:11:25Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1900658177</number>
+		<title>1W7RH820</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=918364a3-7ae7-4d5c-ae5b-276aec1fab21</zipfile_location>
+		<zipfile_datetime>20240227_063714</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:14Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1728450349</number>
+		<title>1R7RM004</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=63ba7e75-7240-4ee7-8d01-288ba76cd376</zipfile_location>
+		<zipfile_datetime>20210903_152902</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T15:29:02Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2496873668</number>
+		<title>7W7BEDIJ</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=aebc3f29-1564-46b1-a08c-28f23c2909e2</zipfile_location>
+		<zipfile_datetime>20181018_220300</zipfile_datetime>
+		<zipfile_datetime_iso8601>2018-10-18T22:03:00Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1327766969</number>
+		<title>5C7D1368</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=21ddef30-f669-4011-961d-29c59c7d4fe4</zipfile_location>
+		<zipfile_datetime>20231109_102406</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-11-09T10:24:06Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3700815521</number>
+		<title>9D7VL026</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=2c1efde3-e942-483c-bec0-29edc3e4617f</zipfile_location>
+		<zipfile_datetime>20230331_063531</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-03-31T06:35:31Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>93734684</number>
+		<title>2WBD1884</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=f3efccf2-5b7a-4418-b481-29ff0507b969</zipfile_location>
+		<zipfile_datetime>20240830_063632</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-30T06:36:32Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>882278187</number>
+		<title>2W7D2200</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=e61ed7b0-8f80-4a1e-9eda-2a4f530b19f5</zipfile_location>
+		<zipfile_datetime>20240403_063648</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-04-03T06:36:48Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4162489012</number>
+		<title>3R7D0763</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=71af111f-4740-4950-a953-2a581791c51d</zipfile_location>
+		<zipfile_datetime>20240821_063621</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-21T06:36:21Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3587979202</number>
+		<title>1W7MO110</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=3a269836-6d68-4b73-96e5-2a73c6766eb1</zipfile_location>
+		<zipfile_datetime>20210908_095517</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:17Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2394298681</number>
+		<title>1W7EH360</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=6e6cfec8-83fa-44e8-b66a-2a954cc2175a</zipfile_location>
+		<zipfile_datetime>20240227_063724</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:24Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2006704745</number>
+		<title>8V8POA03</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=1e3faf6d-090d-4894-a30f-2afb723c32ec</zipfile_location>
+		<zipfile_datetime>20240412_090141</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-04-12T09:01:41Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3282775832</number>
+		<title>2P7D1049</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=18e0fa3e-a316-445b-9f57-2b0a05c23ce5</zipfile_location>
+		<zipfile_datetime>20230408_063535</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-08T06:35:35Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3536447375</number>
+		<title>2WBD2002</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=004d3654-9b31-4790-a313-2b3f8cd89677</zipfile_location>
+		<zipfile_datetime>20240731_063650</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-07-31T06:36:50Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2254979381</number>
+		<title>1W7DHK02</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=09d69936-4a7b-4be3-9838-2b4fcf6eeec3</zipfile_location>
+		<zipfile_datetime>20230413_063523</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-13T06:35:23Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4212255333</number>
+		<title>2WBD1920</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=f85417df-3aa7-4593-b9fb-2b62b5fbc64f</zipfile_location>
+		<zipfile_datetime>20240403_063651</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-04-03T06:36:51Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>472942924</number>
+		<title>4V7OIS06</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=79a21963-0dc2-4a35-bb5c-2bbee071d4dd</zipfile_location>
+		<zipfile_datetime>20240409_164947</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-04-09T16:49:47Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4242533780</number>
+		<title>4V5MOS08</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=4e673992-b0ee-48ec-b05b-2bde40fd6b61</zipfile_location>
+		<zipfile_datetime>20221201_181956</zipfile_datetime>
+		<zipfile_datetime_iso8601>2022-12-01T18:19:56Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1701233844</number>
+		<title>1W7MA010</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=778115cb-e17e-49f4-a70e-2c1b44f3ef7f</zipfile_location>
+		<zipfile_datetime>20210512_145209</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-12T14:52:09Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1193828145</number>
+		<title>1R7NO977</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=76b6e10f-dff4-4427-a911-2c6773222ef8</zipfile_location>
+		<zipfile_datetime>20210903_170743</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T17:07:43Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3098096488</number>
+		<title>1W7NE070</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=d0e9f7e5-775f-4fcc-9fd9-2c6f9190c87d</zipfile_location>
+		<zipfile_datetime>20210914_095426</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-14T09:54:26Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1827801593</number>
+		<title>1W7RH510</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=dd6de3a2-3be8-46a2-9f2f-2c9187f0e28a</zipfile_location>
+		<zipfile_datetime>20240227_063711</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:11Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2488984791</number>
+		<title>9D7EL920</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=df62eb79-5c65-4bd5-8b59-2cef076a6391</zipfile_location>
+		<zipfile_datetime>20230331_063530</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-03-31T06:35:30Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>617519425</number>
+		<title>1W7MO210</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=5262dbd1-995d-43bc-8d2c-2d2c243419d7</zipfile_location>
+		<zipfile_datetime>20210908_095523</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:23Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3298268789</number>
+		<title>2R71028N</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=cdef8e18-62a5-4e1d-9579-2d9f25b05053</zipfile_location>
+		<zipfile_datetime>20210126_112613</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-01-26T11:26:13Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3641244229</number>
+		<title>3R7D0000</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=63026199-a393-4b09-9ff4-2da7ca340f46</zipfile_location>
+		<zipfile_datetime>20240613_063600</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-06-13T06:36:00Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>774815372</number>
+		<title>1W7MA090</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=be7affe0-9598-4ba5-9f89-2dc9775ecd7f</zipfile_location>
+		<zipfile_datetime>20210512_145212</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-12T14:52:12Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2545080978</number>
+		<title>2P7D1249</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=2e0fe715-67a7-4c1f-9f90-2e1981c7ad69</zipfile_location>
+		<zipfile_datetime>20230408_063537</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-08T06:35:37Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1342274189</number>
+		<title>2WBD1872</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=8d8cd022-447a-4303-a444-2e1a41f79313</zipfile_location>
+		<zipfile_datetime>20240614_063709</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-06-14T06:37:09Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1436788039</number>
+		<title>1H7D1709</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=69c89a92-eadf-4df0-9ad4-2e32f00b33ef</zipfile_location>
+		<zipfile_datetime>20211214_095529</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-12-14T09:55:29Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2640559933</number>
+		<title>2WBD2142</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=4c549572-9c1c-4186-92d9-2e54e2a47131</zipfile_location>
+		<zipfile_datetime>20231025_063503</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-10-25T06:35:03Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>500659502</number>
+		<title>7V7GENO5</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=6a155b19-927d-4eb0-bd55-2f328d4679a2</zipfile_location>
+		<zipfile_datetime>20210701_111432</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:14:32Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2619921344</number>
+		<title>3R7D0314</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=644e415c-b1ed-4a77-a09c-2f4407051530</zipfile_location>
+		<zipfile_datetime>20230919_063546</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-09-19T06:35:46Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>636832733</number>
+		<title>1H7TI200</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=c6ed59d5-4a5f-4afc-92e7-2f5b4b855755</zipfile_location>
+		<zipfile_datetime>20211012_145451</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-10-12T14:54:51Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4028504175</number>
+		<title>1W7EL003</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=98fbe914-763b-4f55-94c2-2fd1442099d5</zipfile_location>
+		<zipfile_datetime>20240227_063715</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:15Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3137267661</number>
+		<title>4V5SAO10</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=7f5a26d8-96cd-4f87-b2b1-2ffecf29ca30</zipfile_location>
+		<zipfile_datetime>20201022_171712</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-22T17:17:12Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3458279166</number>
+		<title>7V7BOHE4</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=fdcc5714-ed06-41d8-adb3-305e0d972276</zipfile_location>
+		<zipfile_datetime>20210701_111256</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:12:56Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3559487495</number>
+		<title>2P7D1348</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=7dc4786f-7ec3-4921-b98f-30ac39a79065</zipfile_location>
+		<zipfile_datetime>20230408_063538</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-08T06:35:38Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3357218098</number>
+		<title>1W7EL590</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=b3d72f10-f476-45f1-94e3-31244595920a</zipfile_location>
+		<zipfile_datetime>20230207_063520</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-02-07T06:35:20Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>885696604</number>
+		<title>2WBDHLOB</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=6621c0f9-4c59-4430-bf7c-318906921818</zipfile_location>
+		<zipfile_datetime>20240614_063728</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-06-14T06:37:28Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3107521112</number>
+		<title>3R7D0843</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=e0b9ee6f-04fc-4da8-82fc-31b37cde8232</zipfile_location>
+		<zipfile_datetime>20240821_063623</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-21T06:36:23Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1110473062</number>
+		<title>9D7EL750</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=2d0a2029-19b8-46f3-9862-320aee642e52</zipfile_location>
+		<zipfile_datetime>20230331_063526</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-03-31T06:35:26Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1048018285</number>
+		<title>1W7EL520</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=baea77f8-1e68-40fb-bc83-322c1c2707e0</zipfile_location>
+		<zipfile_datetime>20230207_063519</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-02-07T06:35:19Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2616513391</number>
+		<title>1W7MO240</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=d8bfe7d1-50e3-4a6d-8624-325a5870466c</zipfile_location>
+		<zipfile_datetime>20210908_095523</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:23Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>141182338</number>
+		<title>4V5SAO09</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=04e82005-aeae-4cfa-8a5c-326259b418d4</zipfile_location>
+		<zipfile_datetime>20201022_171712</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-22T17:17:12Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>913255872</number>
+		<title>7V7YZER1</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=492e5f5a-8668-485a-95af-32862ccbe0c6</zipfile_location>
+		<zipfile_datetime>20210701_111302</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:13:02Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1759718556</number>
+		<title>2WBD1874</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=ced8e08b-fa66-40a8-b615-32eeea165fa1</zipfile_location>
+		<zipfile_datetime>20230930_063732</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-09-30T06:37:32Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2648282714</number>
+		<title>1W7NE100</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=3cd593d5-05b0-43e1-bb0a-333f070e018e</zipfile_location>
+		<zipfile_datetime>20220125_095422</zipfile_datetime>
+		<zipfile_datetime_iso8601>2022-01-25T09:54:22Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4025414956</number>
+		<title>3R7D0753</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=48a3e2ec-6536-4969-827a-336b8bb86077</zipfile_location>
+		<zipfile_datetime>20240821_063620</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-21T06:36:20Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>461922715</number>
+		<title>3R7DBB09</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=9fd57c9c-74c6-4991-8287-3397d94e26a4</zipfile_location>
+		<zipfile_datetime>20230214_063449</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-02-14T06:34:49Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3711380288</number>
+		<title>3R7D0809</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=bfe8ff7b-43e8-4654-94c4-34d0a321d860</zipfile_location>
+		<zipfile_datetime>20240821_063622</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-21T06:36:22Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>113617394</number>
+		<title>1W7ML030</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=2733c1b6-56b4-4022-9dea-34f6bae35cc7</zipfile_location>
+		<zipfile_datetime>20210908_095527</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:27Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1442086311</number>
+		<title>2P7D1084</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=f8c6a465-005f-4506-bc8d-34fa10949305</zipfile_location>
+		<zipfile_datetime>20230408_063535</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-08T06:35:35Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1241936703</number>
+		<title>1W7RH550</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=2e01e3d7-fee6-4f74-8ed7-352ca3f30763</zipfile_location>
+		<zipfile_datetime>20240227_063712</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:12Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1610117510</number>
+		<title>3B7D0538</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=f357e967-2274-426c-ae76-3532d8d32bcb</zipfile_location>
+		<zipfile_datetime>20240829_063724</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-29T06:37:24Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3129312221</number>
+		<title>2WBD1894</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=d42dd235-c1e7-489d-8d09-35778b267b82</zipfile_location>
+		<zipfile_datetime>20230930_063738</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-09-30T06:37:38Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2830385608</number>
+		<title>1W7RH370</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=fcdbcdea-7c72-488d-9121-35c0233b593e</zipfile_location>
+		<zipfile_datetime>20240227_063709</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:09Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>353308108</number>
+		<title>1W7RH400</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=3f96ccef-9837-4d4f-8f50-35c3f1eec4b0</zipfile_location>
+		<zipfile_datetime>20210914_095432</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-14T09:54:32Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1291439936</number>
+		<title>BE7BRU01</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=5ca2559f-73e6-4d56-847b-363dcfea5488</zipfile_location>
+		<zipfile_datetime>20230517_082412</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-05-17T08:24:12Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1998638581</number>
+		<title>2WBD1883</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=100c8c5c-0728-4ff1-80c7-369142772b95</zipfile_location>
+		<zipfile_datetime>20240614_063715</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-06-14T06:37:15Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2102537546</number>
+		<title>1W7WDK01</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=575925fc-7c1c-4b6e-904f-36a7b03492ca</zipfile_location>
+		<zipfile_datetime>20240227_063707</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:07Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3472009505</number>
+		<title>1W7HO107</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=b15ebe62-8d87-4f76-be5f-36e3058bc1a1</zipfile_location>
+		<zipfile_datetime>20210205_120405</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-02-05T12:04:05Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1572205390</number>
+		<title>3RB4DCG1</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=7808d5e3-cd97-4886-97d4-36e5504570a2</zipfile_location>
+		<zipfile_datetime>20230919_063548</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-09-19T06:35:48Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>751916115</number>
+		<title>7V7BOHE3</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=babf7d4a-237e-44ab-a3a3-36f3e356ef16</zipfile_location>
+		<zipfile_datetime>20210701_111255</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:12:55Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2745214156</number>
+		<title>1H7TI390</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=7b9ec172-18ba-4538-8b06-3772da6ea4ac</zipfile_location>
+		<zipfile_datetime>20211012_145457</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-10-12T14:54:57Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2717174219</number>
+		<title>1W7TEK00</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=b1b6b075-1c9c-4547-98b3-37e589f338a3</zipfile_location>
+		<zipfile_datetime>20230126_063502</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-01-26T06:35:02Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2416119867</number>
+		<title>2W7D2090</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=32c03e4b-13ff-4d11-8dac-37e7d98b06c4</zipfile_location>
+		<zipfile_datetime>20230930_063705</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-09-30T06:37:05Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2120585913</number>
+		<title>9D7EL930</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=28ddecf4-2a5e-4876-b23d-37ff535e4b2c</zipfile_location>
+		<zipfile_datetime>20230331_063530</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-03-31T06:35:30Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2962389248</number>
+		<title>1W7EL000</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=4a65dfde-700b-42de-a993-385034edf0cd</zipfile_location>
+		<zipfile_datetime>20240227_063715</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:15Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3371780525</number>
+		<title>1R7AR063</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=e33e34a3-7cc8-4aca-8629-38702d575861</zipfile_location>
+		<zipfile_datetime>20210903_145745</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T14:57:45Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>463223555</number>
+		<title>1H7D1762</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=e2a9533c-0ea3-48c4-a3cd-388085746819</zipfile_location>
+		<zipfile_datetime>20230712_063527</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-07-12T06:35:27Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1272008609</number>
+		<title>2P7D1267</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=6f3727d8-775a-44b8-ad9b-388168c23c23</zipfile_location>
+		<zipfile_datetime>20230408_063537</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-08T06:35:37Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2637969394</number>
+		<title>2WBD1905</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=8f50b685-b8e2-463a-8abd-38832b1194e3</zipfile_location>
+		<zipfile_datetime>20240614_063722</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-06-14T06:37:22Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>475713525</number>
+		<title>1W7SR020</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=27e48aed-c006-49cf-be5d-38bd97c9a36e</zipfile_location>
+		<zipfile_datetime>20210908_095524</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:24Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1529223465</number>
+		<title>2P7D1414</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=47faa834-3a5a-4fb7-b4c8-38d60c18b36f</zipfile_location>
+		<zipfile_datetime>20230408_063539</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-08T06:35:39Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2000651288</number>
+		<title>7V7ZEEK2</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=44c5bc73-9d42-4f70-9378-38e0095595cd</zipfile_location>
+		<zipfile_datetime>20210701_112121</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:21:21Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1194269547</number>
+		<title>1W7ML020</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=d5f61f16-8a82-49cf-bca5-392a2b25b150</zipfile_location>
+		<zipfile_datetime>20210908_095527</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:27Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>844245582</number>
+		<title>2WBD2091</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=adb09efa-63ac-4423-9dbf-3999c15d2265</zipfile_location>
+		<zipfile_datetime>20230929_063650</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-09-29T06:36:50Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4080231480</number>
+		<title>1H7TI490</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=5dcb834c-12c6-49b0-b5f2-399ff3cb34d8</zipfile_location>
+		<zipfile_datetime>20211012_145500</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-10-12T14:55:00Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2064321574</number>
+		<title>1R7LE959</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=12c064a3-e89e-4764-b52e-3a3926df6c1b</zipfile_location>
+		<zipfile_datetime>20210903_140514</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T14:05:14Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2165057660</number>
+		<title>1W7RH430</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=1481a2ba-bea8-4a04-9199-3ade63a9c81c</zipfile_location>
+		<zipfile_datetime>20240227_063710</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:10Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2578004389</number>
+		<title>1R7YS899</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=c6073832-08b5-4fcd-8ebc-3aea143aa86b</zipfile_location>
+		<zipfile_datetime>20210903_122004</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T12:20:04Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3959945608</number>
+		<title>7V7GENO2</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=86fae06e-faf8-4c03-985f-3b0cdcca75aa</zipfile_location>
+		<zipfile_datetime>20210701_111430</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:14:30Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3701400578</number>
+		<title>2WBD2025</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=8ecede80-4b83-4ddf-b7cc-3b27877ac4b0</zipfile_location>
+		<zipfile_datetime>20240731_063655</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-07-31T06:36:55Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>689286690</number>
+		<title>1W7ML050</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=b1318b6c-167a-4dc2-bbe7-3b29709fc090</zipfile_location>
+		<zipfile_datetime>20210908_095527</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:27Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1594291499</number>
+		<title>1W7MO070</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=c592f54e-6f77-446f-8599-3b9dccb93bf1</zipfile_location>
+		<zipfile_datetime>20210908_095516</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:16Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1278932485</number>
+		<title>1W7KK001</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=cb07d2e2-10b1-4cc8-b09a-3ba633544fd4</zipfile_location>
+		<zipfile_datetime>20210503_145616</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-03T14:56:16Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3767654055</number>
+		<title>1W7SO060</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=b6752ceb-435b-4452-bcd3-3c80801f16c3</zipfile_location>
+		<zipfile_datetime>20221103_063448</zipfile_datetime>
+		<zipfile_datetime_iso8601>2022-11-03T06:34:48Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3537599063</number>
+		<title>1W7MA160</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=d30d99d6-9213-454b-9f5e-3c8c2b920fcb</zipfile_location>
+		<zipfile_datetime>20210512_145215</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-12T14:52:15Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>927119835</number>
+		<title>2WBDHLIH</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=acf497d5-a054-4733-b30e-3ccb204f6f88</zipfile_location>
+		<zipfile_datetime>20240830_063636</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-30T06:36:36Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>323987015</number>
+		<title>1W7EL100</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=a2e884d7-7153-43d6-96b7-3ccb44328bc4</zipfile_location>
+		<zipfile_datetime>20240227_063717</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:17Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1577410030</number>
+		<title>7V7ZWV02</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=57ed8de0-be67-4ee5-9255-3cf2d34e5c36</zipfile_location>
+		<zipfile_datetime>20210701_105058</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T10:50:58Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2139904351</number>
+		<title>1W7EL240</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=c01a06ed-13a3-4005-8f71-3d26be3dd18b</zipfile_location>
+		<zipfile_datetime>20240227_063719</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:19Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4092020823</number>
+		<title>2W7D2160</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=3c4c4407-6c8e-4748-b6ab-3d530bcc08be</zipfile_location>
+		<zipfile_datetime>20240614_063707</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-06-14T06:37:07Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>929739770</number>
+		<title>7V7YZER2</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=a42ef388-f16a-4892-b9c7-3d5d91f40a6c</zipfile_location>
+		<zipfile_datetime>20210701_111302</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:13:02Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1050819301</number>
+		<title>1W7KK005</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=3cf4f721-c7e8-4d1e-9270-3db7f143432e</zipfile_location>
+		<zipfile_datetime>20240227_063707</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:07Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>236288161</number>
+		<title>1R7NR902</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=b904c989-6f41-453f-ae66-3dc689041678</zipfile_location>
+		<zipfile_datetime>20210903_152217</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T15:22:17Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>657613918</number>
+		<title>1W7MA040</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=573c6962-ab6c-40e4-a4ad-3df9046e034f</zipfile_location>
+		<zipfile_datetime>20210512_145209</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-12T14:52:09Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>822423611</number>
+		<title>2P7D0985</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=8a635faa-dc97-45f2-ae52-3dfcd935152f</zipfile_location>
+		<zipfile_datetime>20230408_063534</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-08T06:35:34Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1628014897</number>
+		<title>7V7LEIE3</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=5ae88f8b-d938-4d61-9b40-3e4216cbb25b</zipfile_location>
+		<zipfile_datetime>20210701_112114</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:21:14Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3470315287</number>
+		<title>1W7EL190</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=753bf084-cf58-4d91-abdf-3e4c1be58545</zipfile_location>
+		<zipfile_datetime>20240227_063718</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:18Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>102350718</number>
+		<title>9D7EL900</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=b88306ef-99bd-40e5-a807-3e6bbb82bbab</zipfile_location>
+		<zipfile_datetime>20230331_063530</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-03-31T06:35:30Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2240737105</number>
+		<title>1R7MA114</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=85b742e0-8d6f-4ae7-8dff-3e866ca78d8a</zipfile_location>
+		<zipfile_datetime>20210607_223041</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-06-07T22:30:41Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1037642903</number>
+		<title>3R7D0349</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=255a0d9a-07b2-4cc9-8b65-3eb691eee83c</zipfile_location>
+		<zipfile_datetime>20230919_063547</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-09-19T06:35:47Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1880090206</number>
+		<title>1W7EL050</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=ff141393-8135-4180-b808-3ec580140ba8</zipfile_location>
+		<zipfile_datetime>20240227_063716</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:16Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>446915602</number>
+		<title>2W7D2070</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=af4349c3-2cf4-46ec-8e1a-3ed1c47e5af0</zipfile_location>
+		<zipfile_datetime>20240731_063648</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-07-31T06:36:48Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1610750309</number>
+		<title>7V7ALBK7</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=6bcc6909-6c7e-4ecf-9658-3ee6942dba71</zipfile_location>
+		<zipfile_datetime>20210701_110747</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:07:47Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1105118388</number>
+		<title>2P7D1332</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=bc3c163d-868b-446d-bb47-3f2176e5cb40</zipfile_location>
+		<zipfile_datetime>20230408_063538</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-08T06:35:38Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2931367100</number>
+		<title>3B7D0375</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=54a32331-7f04-45fa-9cd0-3f2ec5f7dc9d</zipfile_location>
+		<zipfile_datetime>20240829_063720</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-29T06:37:20Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1898608743</number>
+		<title>1W7EL480</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=7688a74f-345c-4ccb-ac88-3f412a8bfb49</zipfile_location>
+		<zipfile_datetime>20240227_063724</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:24Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1169265797</number>
+		<title>1R7AR001</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=c77801fa-f02b-4e2a-a417-3f4f9cd1a50e</zipfile_location>
+		<zipfile_datetime>20210313_184039</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-03-13T18:40:39Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3211039007</number>
+		<title>1W7HVK12</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=7fd82734-0fc9-49e2-b64e-3f61a1233d76</zipfile_location>
+		<zipfile_datetime>20230804_063501</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-08-04T06:35:01Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>917988740</number>
+		<title>1R7ZA005</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=7adf8903-a6f6-4504-8e9b-3f65767997e0</zipfile_location>
+		<zipfile_datetime>20210903_132705</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T13:27:05Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3177777620</number>
+		<title>2P7D1284</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=b221bb01-7d2f-4037-a7db-3ff45062b87b</zipfile_location>
+		<zipfile_datetime>20210118_145400</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-01-18T14:54:00Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2379361127</number>
+		<title>7V7ALBK4</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=a63ef310-5f28-47c5-b0ee-407c306f04d5</zipfile_location>
+		<zipfile_datetime>20210701_110746</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:07:46Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3491259311</number>
+		<title>3R7D0200</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=19e6d126-b727-4de8-8e04-40a8e4c30b6d</zipfile_location>
+		<zipfile_datetime>20240613_063558</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-06-13T06:35:58Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2431688103</number>
+		<title>1W7WE290</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=3ec1406c-5aee-439a-bc84-40d883b1d6c2</zipfile_location>
+		<zipfile_datetime>20210908_095539</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:39Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2123379082</number>
+		<title>1W7UH120</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=5acc0991-b2cc-4768-a0f9-40eec23ecbd4</zipfile_location>
+		<zipfile_datetime>20230804_063459</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-08-04T06:34:59Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3489581906</number>
+		<title>1W7DE021</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=1a6ce25b-ff30-4a67-8507-41338089c523</zipfile_location>
+		<zipfile_datetime>20210503_145615</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-03T14:56:15Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>650672317</number>
+		<title>9D7EL770</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=783c99b3-2745-4424-b9b8-4161c8adfe25</zipfile_location>
+		<zipfile_datetime>20230331_063528</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-03-31T06:35:28Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>341562789</number>
+		<title>1H7TI260</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=93d54f4c-44f7-48ea-b8cb-41b42f4ff913</zipfile_location>
+		<zipfile_datetime>20211012_145454</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-10-12T14:54:54Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2994215122</number>
+		<title>1W7D2390</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=2e3cb83a-fca8-4cd5-a71e-41b80921e80d</zipfile_location>
+		<zipfile_datetime>20220611_063524</zipfile_datetime>
+		<zipfile_datetime_iso8601>2022-06-11T06:35:24Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3022911461</number>
+		<title>2P7D1337</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=d0c38f2e-8a5e-4507-8175-41de265631bb</zipfile_location>
+		<zipfile_datetime>20230408_063538</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-08T06:35:38Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1188614900</number>
+		<title>2WBD2100</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=10d4d5aa-964f-40dc-9b9d-41f7089e2ba8</zipfile_location>
+		<zipfile_datetime>20240529_063639</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-05-29T06:36:39Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3706919423</number>
+		<title>1W7HVK22</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=acf9d1a5-28aa-4436-a35c-42179e4ca3dd</zipfile_location>
+		<zipfile_datetime>20230804_063501</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-08-04T06:35:01Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1985497139</number>
+		<title>3R7DBB02</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=56c5fcc1-f264-4dda-ab51-4251f7f25367</zipfile_location>
+		<zipfile_datetime>20230214_063448</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-02-14T06:34:48Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>666487586</number>
+		<title>1W7RH460</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=922c8ff2-7c7e-493e-9425-42560bc5d74f</zipfile_location>
+		<zipfile_datetime>20240227_063710</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:10Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3969208893</number>
+		<title>2P7SA088</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=c4d7c041-075e-472d-a87b-42687f32513e</zipfile_location>
+		<zipfile_datetime>20230413_063522</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-13T06:35:22Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2681821564</number>
+		<title>1W7NE160</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=e97656f9-b44a-4e0f-916b-427bc29d3fd2</zipfile_location>
+		<zipfile_datetime>20210914_095428</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-14T09:54:28Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1606172412</number>
+		<title>1W7SL065</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=24ebfaf1-d3c5-4c32-bfcd-427beb6afb9c</zipfile_location>
+		<zipfile_datetime>20231011_063506</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-10-11T06:35:06Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3259868094</number>
+		<title>1R7WZ009</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=f939a372-cd4e-4461-8687-42e292d84135</zipfile_location>
+		<zipfile_datetime>20210903_110214</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T11:02:14Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1241764366</number>
+		<title>1H7TI510</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=78ef8bdf-71fa-46f8-a485-42e7b4dd8498</zipfile_location>
+		<zipfile_datetime>20211012_145500</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-10-12T14:55:00Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1040227284</number>
+		<title>1R7WA887</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=059eb2d2-87ad-43b5-954c-42f441607872</zipfile_location>
+		<zipfile_datetime>20210903_144508</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T14:45:08Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1420855776</number>
+		<title>1W7MO100</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=1edf62a9-0b36-41bb-b660-4309f630d10a</zipfile_location>
+		<zipfile_datetime>20210908_095517</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:17Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4031380502</number>
+		<title>3R7D1028</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=1f6777c4-b7bf-4463-b498-4318a93e2469</zipfile_location>
+		<zipfile_datetime>20201209_103453</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-12-09T10:34:53Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2446056493</number>
+		<title>3R7D0833</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=80fb64b2-3434-4fea-8a3a-43731fdb0f24</zipfile_location>
+		<zipfile_datetime>20240821_063623</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-21T06:36:23Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3563114934</number>
+		<title>3R7SFG02</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=ab062f2d-c38d-433b-b36c-43868fff8a51</zipfile_location>
+		<zipfile_datetime>20201016_162825</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-16T16:28:25Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>215477785</number>
+		<title>2R71033S</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=973a2046-a259-4ab1-95ee-43913bd04dcc</zipfile_location>
+		<zipfile_datetime>20210126_112613</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-01-26T11:26:13Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1639359719</number>
+		<title>4V5SAO01</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=326f37e6-df6c-41e8-88ea-43de2a1426ec</zipfile_location>
+		<zipfile_datetime>20201022_171712</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-22T17:17:12Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2226882647</number>
+		<title>1W7RH730</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=4f8bf661-40d7-4dba-88c8-43e1775afefe</zipfile_location>
+		<zipfile_datetime>20210503_145645</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-03T14:56:45Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1597603501</number>
+		<title>1H7TI410</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=b88a50c3-5a2b-4fc9-b77c-440805e3f0a1</zipfile_location>
+		<zipfile_datetime>20211012_145458</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-10-12T14:54:58Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1018611506</number>
+		<title>3R7BM007</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=a53534e7-0c35-4070-a771-4415be43bb16</zipfile_location>
+		<zipfile_datetime>20220326_095421</zipfile_datetime>
+		<zipfile_datetime_iso8601>2022-03-26T09:54:21Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1923346860</number>
+		<title>2P7D0929</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=cfc060a0-d2f0-47f1-a3ef-448045901d87</zipfile_location>
+		<zipfile_datetime>20230408_063534</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-08T06:35:34Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>756520892</number>
+		<title>1W7RH680</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=770480fd-dd56-490e-a1e2-451a8184460a</zipfile_location>
+		<zipfile_datetime>20230413_063525</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-13T06:35:25Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1284945616</number>
+		<title>1H7TI570</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=1344dc92-ba6e-4a2c-8610-45367e1f7e1b</zipfile_location>
+		<zipfile_datetime>20211012_145503</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-10-12T14:55:03Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>963790025</number>
+		<title>1W7SR070</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=3237c517-2012-45b0-aacd-454315ea8e19</zipfile_location>
+		<zipfile_datetime>20210908_095525</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:25Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>443548807</number>
+		<title>3R7D0680</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=68ecb081-c709-4e46-a18c-454eb043181d</zipfile_location>
+		<zipfile_datetime>20240821_063617</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-21T06:36:17Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>595512087</number>
+		<title>1R7WZ001</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=b282a6c9-b70e-474a-8c2b-457566060d78</zipfile_location>
+		<zipfile_datetime>20210712_113106</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-12T11:31:06Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3893127912</number>
+		<title>1W7EL310</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=845029f3-81f7-4575-99c8-458a83a7f122</zipfile_location>
+		<zipfile_datetime>20240227_063720</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:20Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1197826929</number>
+		<title>2WBDHYBB</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=345df9db-278c-4ac7-8bf3-4606412b4ffe</zipfile_location>
+		<zipfile_datetime>20230929_063654</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-09-29T06:36:54Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>211867981</number>
+		<title>2P7TI164</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=a1b5703f-1cbc-4be2-b446-46168c4ff8e4</zipfile_location>
+		<zipfile_datetime>20230408_063543</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-08T06:35:43Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>507301672</number>
+		<title>7V7ALBK9</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=db676f8c-242c-40b6-a623-468fd32255ad</zipfile_location>
+		<zipfile_datetime>20210701_110748</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:07:48Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2882153884</number>
+		<title>1W7RH630</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=b190f13d-94aa-4cc4-b8d3-46bf920b7b71</zipfile_location>
+		<zipfile_datetime>20210914_095441</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-14T09:54:41Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2340472561</number>
+		<title>1W7UH000</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=4d1c2e70-5243-4a4b-a87b-46f92ac99b22</zipfile_location>
+		<zipfile_datetime>20230804_063502</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-08-04T06:35:02Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3192241524</number>
+		<title>1W7HO010</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=282379e3-c3f0-4733-b3f6-46fbf68108cb</zipfile_location>
+		<zipfile_datetime>20201016_162828</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-16T16:28:28Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>865082243</number>
+		<title>1W7NE090</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=c7cf0ad6-6e7e-496c-a088-4701667c4a60</zipfile_location>
+		<zipfile_datetime>20210914_095427</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-14T09:54:27Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>315465050</number>
+		<title>2W7D1950</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=a37b247d-6076-4399-a3d2-470d177fbc66</zipfile_location>
+		<zipfile_datetime>20240614_063705</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-06-14T06:37:05Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2409089700</number>
+		<title>1W7MA320</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=8c0b8207-9465-4b07-be42-47a13c8c5b59</zipfile_location>
+		<zipfile_datetime>20210512_145218</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-12T14:52:18Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1143849137</number>
+		<title>4V7SEI15</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=ada5a2d5-e423-4ddb-a897-47f6e94444ca</zipfile_location>
+		<zipfile_datetime>20240409_164053</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-04-09T16:40:53Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>581074449</number>
+		<title>1W7RH280</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=27163af7-5b12-4c71-a6d2-47f8d55ab4e9</zipfile_location>
+		<zipfile_datetime>20201022_171711</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-22T17:17:11Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2671624216</number>
+		<title>2W7D2010</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=b52b132b-bc20-4ca4-9c64-481822613f59</zipfile_location>
+		<zipfile_datetime>20230930_063659</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-09-30T06:36:59Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1460890085</number>
+		<title>4V7OIS04</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=c8afe146-02e7-4f58-b146-4840a7344247</zipfile_location>
+		<zipfile_datetime>20240409_165020</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-04-09T16:50:20Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3889054553</number>
+		<title>2WBD2201</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=dcbbbed1-b6ab-4b71-938d-4866500a0652</zipfile_location>
+		<zipfile_datetime>20240131_063611</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-01-31T06:36:11Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3001177910</number>
+		<title>7W7ALEI1</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=f29e11a7-22e8-4773-92e9-48b500c2526c</zipfile_location>
+		<zipfile_datetime>20181018_211038</zipfile_datetime>
+		<zipfile_datetime_iso8601>2018-10-18T21:10:38Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1788784351</number>
+		<title>1H7TI500</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=a0cb5dd2-ff95-432e-b24a-48f0d8061c05</zipfile_location>
+		<zipfile_datetime>20211012_145500</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-10-12T14:55:00Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>568483080</number>
+		<title>7V7PLDU3</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=3978b1ba-654c-48c1-9cfe-490255803db8</zipfile_location>
+		<zipfile_datetime>20210701_111436</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:14:36Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3691659864</number>
+		<title>1W7DE020</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=c09ef16c-ac6f-4ceb-ae81-49729df5d4c1</zipfile_location>
+		<zipfile_datetime>20210503_145614</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-03T14:56:14Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3689066462</number>
+		<title>2WBD1886</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=4d9e8ef8-d46d-4645-a461-4999307e367b</zipfile_location>
+		<zipfile_datetime>20230930_063738</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-09-30T06:37:38Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1897736702</number>
+		<title>1W7EL130</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=5ecbed43-1447-4c19-9f19-49e39c139163</zipfile_location>
+		<zipfile_datetime>20240227_063717</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:17Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1021253143</number>
+		<title>1W7EL330</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=2c205878-9457-4fa3-a776-4a462e6b9d59</zipfile_location>
+		<zipfile_datetime>20240227_063721</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:21Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2268457996</number>
+		<title>3R7D0864</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=0e9bda73-b73f-45da-8746-4a67dbdee645</zipfile_location>
+		<zipfile_datetime>20201209_103450</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-12-09T10:34:50Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1005186043</number>
+		<title>1W7WDK04</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=aa596118-dcdf-4f80-8f4d-4a774030fa27</zipfile_location>
+		<zipfile_datetime>20210503_145618</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-03T14:56:18Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>747437724</number>
+		<title>1W7D2250</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=c48c311e-790c-400e-b253-4abe6a0f4caf</zipfile_location>
+		<zipfile_datetime>20220611_063523</zipfile_datetime>
+		<zipfile_datetime_iso8601>2022-06-11T06:35:23Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1354421819</number>
+		<title>1W7MO020</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=65b81360-be49-4c59-9df7-4b06280b4d73</zipfile_location>
+		<zipfile_datetime>20210908_095515</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:15Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2268006134</number>
+		<title>1W7NE030</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=fd7ecbd0-de98-4faf-b77c-4b355b80855d</zipfile_location>
+		<zipfile_datetime>20210914_095422</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-14T09:54:22Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3149863077</number>
+		<title>1H7TI170</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=9ee20674-ccef-40af-9bab-4b3b7578ffb4</zipfile_location>
+		<zipfile_datetime>20211012_145450</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-10-12T14:54:50Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2759786725</number>
+		<title>9D7EL760</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=bf5be8cc-9cfe-40e8-af70-4b453283aefa</zipfile_location>
+		<zipfile_datetime>20230331_063526</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-03-31T06:35:26Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1075450804</number>
+		<title>3R7SFG06</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=51483bdb-4afd-4726-8d9d-4b690befa1c9</zipfile_location>
+		<zipfile_datetime>20201016_162825</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-16T16:28:25Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2935486087</number>
+		<title>9D7VL067</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=40861126-b5cb-433a-86ca-4bbc08125459</zipfile_location>
+		<zipfile_datetime>20230331_063531</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-03-31T06:35:31Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2570482308</number>
+		<title>7V7ALEI2</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=ae500209-65d1-42a2-9c08-4bf5c813a879</zipfile_location>
+		<zipfile_datetime>20210701_110749</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:07:49Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2943033530</number>
+		<title>1H7TI450</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=43779ec1-e1c1-4e27-8057-4c0021a350e0</zipfile_location>
+		<zipfile_datetime>20211012_145459</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-10-12T14:54:59Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4272563612</number>
+		<title>1R7WA931</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=a1183473-6965-40a8-bab1-4c23f846b24e</zipfile_location>
+		<zipfile_datetime>20210903_144721</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T14:47:21Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>575023223</number>
+		<title>3R7D0041</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=7d14febd-0984-4ff8-a5ac-4c5e24f9b5a3</zipfile_location>
+		<zipfile_datetime>20240613_063602</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-06-13T06:36:02Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2293325811</number>
+		<title>1W7EL010</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=d4f805d6-2696-4e72-950c-4c5f0baf6094</zipfile_location>
+		<zipfile_datetime>20240227_063715</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:15Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3332487752</number>
+		<title>2WBD2024</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=d7f2ccad-3878-44b2-9178-4c65c403f807</zipfile_location>
+		<zipfile_datetime>20240731_063654</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-07-31T06:36:54Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3088876887</number>
+		<title>1W7MO160</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=acef15b6-beb5-4fb3-a6a8-4cb1c3dcbd9e</zipfile_location>
+		<zipfile_datetime>20210908_095521</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:21Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1663010882</number>
+		<title>1W7MO030</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=89439435-8906-4b3c-813e-4cb5d17d0fdd</zipfile_location>
+		<zipfile_datetime>20210908_095515</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:15Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4129177516</number>
+		<title>9D7EL790</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=501c81ad-4c12-44f3-ac28-4d03423699a0</zipfile_location>
+		<zipfile_datetime>20230331_063528</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-03-31T06:35:28Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4280404812</number>
+		<title>2P7TI090</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=bb2e0242-1706-4e29-ade6-4d5cca7a920f</zipfile_location>
+		<zipfile_datetime>20230408_063542</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-08T06:35:42Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1941763668</number>
+		<title>9D7EL850</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=22caab9e-6657-4705-9734-4d5f400c4982</zipfile_location>
+		<zipfile_datetime>20230331_063529</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-03-31T06:35:29Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1578479947</number>
+		<title>4V5007DE</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=ad4fff30-56dc-4f66-b11d-4d8a9102bd6b</zipfile_location>
+		<zipfile_datetime>20201022_171704</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-22T17:17:04Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2697861885</number>
+		<title>1W7MO120</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=5bfdb1e5-3c25-4d91-8d9d-4d922a4907b6</zipfile_location>
+		<zipfile_datetime>20210908_095518</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:18Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1124624301</number>
+		<title>9D7EL810</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=311ffe27-6c30-456c-b978-4e1a4d130942</zipfile_location>
+		<zipfile_datetime>20230331_063528</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-03-31T06:35:28Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>821588830</number>
+		<title>1W7RH500</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=2ae57c0e-96e2-4c2c-9e23-4e43616875a3</zipfile_location>
+		<zipfile_datetime>20240227_063711</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:11Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>264673962</number>
+		<title>2W7D2000</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=08b69fc2-9916-4b6b-b321-4e473bee536b</zipfile_location>
+		<zipfile_datetime>20240614_063707</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-06-14T06:37:07Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4236646927</number>
+		<title>2P7TI142</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=352d5af8-bdfe-4838-9895-4e550d92aedd</zipfile_location>
+		<zipfile_datetime>20230408_063543</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-08T06:35:43Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2544317247</number>
+		<title>1W7EL280</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=66eee1ff-ec78-42f7-a5a2-4e62a1a42399</zipfile_location>
+		<zipfile_datetime>20240227_063720</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:20Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3622339044</number>
+		<title>7V7YZER3</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=933561f3-c85a-4255-a23a-4ede0a4be174</zipfile_location>
+		<zipfile_datetime>20210701_111302</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:13:02Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3203774809</number>
+		<title>1W7HO000</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=070f3eea-2712-4185-a1c6-4ee1ef150099</zipfile_location>
+		<zipfile_datetime>20230804_063458</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-08-04T06:34:58Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>582953477</number>
+		<title>3R7D0178</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=288de9b3-5821-4018-963d-4ee548b4a407</zipfile_location>
+		<zipfile_datetime>20240613_063558</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-06-13T06:35:58Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2586633167</number>
+		<title>2W7D1970</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=fdf53c66-de8d-4695-8b80-4f6b9db7d1b3</zipfile_location>
+		<zipfile_datetime>20230930_063646</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-09-30T06:36:46Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2377403123</number>
+		<title>7V7BOSC3</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=e0b2951d-0419-45a7-87ec-4fa92af1434c</zipfile_location>
+		<zipfile_datetime>20210701_111120</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:11:20Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>787623237</number>
+		<title>1W7EL370</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=04fdbf36-d8dc-43be-8866-4fe2283c3c08</zipfile_location>
+		<zipfile_datetime>20240227_063722</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:22Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>259803619</number>
+		<title>3R7DBB06</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=2080e7f7-c021-4601-9857-4fe63baa9008</zipfile_location>
+		<zipfile_datetime>20230214_063449</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-02-14T06:34:49Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4285730888</number>
+		<title>3R7DCC02</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=35ac6ac1-f263-471e-97ca-4fe865343f1d</zipfile_location>
+		<zipfile_datetime>20220423_095652</zipfile_datetime>
+		<zipfile_datetime_iso8601>2022-04-23T09:56:52Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2363317392</number>
+		<title>2P7SA059</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=e55123f6-2c39-40a7-8fdf-4fec3f0b032c</zipfile_location>
+		<zipfile_datetime>20230413_063522</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-13T06:35:22Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2351646238</number>
+		<title>1W7UH040</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=1a7f1212-65ac-4117-9f7d-4fef095dcde7</zipfile_location>
+		<zipfile_datetime>20230804_063502</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-08-04T06:35:02Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4024504728</number>
+		<title>1W7ML150</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=171a9468-9dd3-4c6c-98e1-4ffea6533809</zipfile_location>
+		<zipfile_datetime>20210908_095530</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:30Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1336885130</number>
+		<title>4V5MOS01</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=bcda4ffb-4dcf-4302-9235-504a10b92583</zipfile_location>
+		<zipfile_datetime>20221201_181552</zipfile_datetime>
+		<zipfile_datetime_iso8601>2022-12-01T18:15:52Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2617174381</number>
+		<title>1W7WE250</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=b188b8fb-6dcc-446f-9712-5056564e2656</zipfile_location>
+		<zipfile_datetime>20210908_095538</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:38Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3154854691</number>
+		<title>2P7D0970</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=677ebd6d-8a61-4abc-99d4-50818f502f8f</zipfile_location>
+		<zipfile_datetime>20230408_063534</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-08T06:35:34Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2651508977</number>
+		<title>1W7EL220</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=aa93b843-d5f1-4759-b983-508d184865f3</zipfile_location>
+		<zipfile_datetime>20240227_063719</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:19Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>141492417</number>
+		<title>1H7SZD00</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=b3b503f1-1270-4ba6-a151-50ac9d83f447</zipfile_location>
+		<zipfile_datetime>20230712_063528</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-07-12T06:35:28Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2797720093</number>
+		<title>1W7WDK03</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=503da18b-5a9d-47a5-9450-50b5060e621d</zipfile_location>
+		<zipfile_datetime>20210908_095514</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:14Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4292744825</number>
+		<title>2P7D1207</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=dd6ce3a2-a201-41cf-bd3b-50b98636264b</zipfile_location>
+		<zipfile_datetime>20230408_063537</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-08T06:35:37Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3707717200</number>
+		<title>1R7HY001</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=e1eeaa55-c7b7-4795-96dd-50f906170fe3</zipfile_location>
+		<zipfile_datetime>20210903_135223</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T13:52:23Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1678464414</number>
+		<title>1R7BE967</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=844cca78-af2a-4353-93c7-5155cdd89e60</zipfile_location>
+		<zipfile_datetime>20210903_154755</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T15:47:55Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1803704412</number>
+		<title>7W7BOSC5</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=334af2dc-ec72-47fd-b83d-51d8c95a3cf6</zipfile_location>
+		<zipfile_datetime>20181018_211038</zipfile_datetime>
+		<zipfile_datetime_iso8601>2018-10-18T21:10:38Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>357971719</number>
+		<title>7V7LOKAN</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=5510da6a-0ac0-4c29-b8fd-5214c97ff144</zipfile_location>
+		<zipfile_datetime>20210701_112115</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:21:15Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3254414740</number>
+		<title>7V7BZS03</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=32d7018e-e803-4e44-9187-5246abf82aea</zipfile_location>
+		<zipfile_datetime>20210701_111122</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:11:22Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2500361666</number>
+		<title>1W7LA130</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=b27b2d88-9e87-4912-8870-52cc8bd66716</zipfile_location>
+		<zipfile_datetime>20210914_095421</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-14T09:54:21Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>901362499</number>
+		<title>2W7D2030</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=d7059f9b-ff3c-4dba-bcea-52dee33a2565</zipfile_location>
+		<zipfile_datetime>20230930_063734</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-09-30T06:37:34Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>826185834</number>
+		<title>4V5MOS04</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=8c2c8eca-152c-43ad-b082-52ff4d7d4d36</zipfile_location>
+		<zipfile_datetime>20221201_181812</zipfile_datetime>
+		<zipfile_datetime_iso8601>2022-12-01T18:18:12Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1396495795</number>
+		<title>1R7MK075</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=c8f506ab-ddcc-4db4-a5e5-532b14cfd4fe</zipfile_location>
+		<zipfile_datetime>20210903_151114</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T15:11:14Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1462471754</number>
+		<title>1W7UH020</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=b0144937-55ba-4506-a924-5339f057aa10</zipfile_location>
+		<zipfile_datetime>20230804_063502</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-08-04T06:35:02Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3841349126</number>
+		<title>4V7OIS01</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=645991f7-4b53-4c99-a2c4-534793140826</zipfile_location>
+		<zipfile_datetime>20240409_171409</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-04-09T17:14:09Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>189413741</number>
+		<title>1W7MA180</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=a4c8f6ba-f174-4026-aa5c-5359b2554240</zipfile_location>
+		<zipfile_datetime>20210512_145215</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-12T14:52:15Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3593216274</number>
+		<title>1R7MA151</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=c9dbab4b-0309-439b-b4ee-53bb48e95ee7</zipfile_location>
+		<zipfile_datetime>20210607_223347</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-06-07T22:33:47Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4258555728</number>
+		<title>3R7PAM02</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=93e36338-9890-4856-af50-53fd38156f70</zipfile_location>
+		<zipfile_datetime>20220423_095654</zipfile_datetime>
+		<zipfile_datetime_iso8601>2022-04-23T09:56:54Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2031895851</number>
+		<title>1W7MO090</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=50a99e67-04d2-4587-b302-542b551aa8d3</zipfile_location>
+		<zipfile_datetime>20210908_095516</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:16Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2475644443</number>
+		<title>2P7TI080</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=afa82f27-f90f-4be1-ae45-5441590375ad</zipfile_location>
+		<zipfile_datetime>20230408_063542</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-08T06:35:42Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2317868982</number>
+		<title>2WBD1911</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=e2bb43ce-a614-4740-b099-549189e4e199</zipfile_location>
+		<zipfile_datetime>20240614_063723</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-06-14T06:37:23Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1902715724</number>
+		<title>7V7DTS06</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=1379ed78-ff84-4546-822e-5523f18328e1</zipfile_location>
+		<zipfile_datetime>20210701_111300</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:13:00Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>464020290</number>
+		<title>1W7MA290</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=572e2f4c-e6b2-4372-9e32-5550611da02a</zipfile_location>
+		<zipfile_datetime>20210512_145217</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-12T14:52:17Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>529564326</number>
+		<title>3R7D1039</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=c236ed2e-c248-4f46-b3a1-55c54d0b129e</zipfile_location>
+		<zipfile_datetime>20201209_103453</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-12-09T10:34:53Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>679556241</number>
+		<title>4V7SEI04</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=91a867a9-bff8-4cd1-b823-55d837734428</zipfile_location>
+		<zipfile_datetime>20240409_164120</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-04-09T16:41:20Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3450028466</number>
+		<title>2WBD2210</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=bb23607d-c0f9-48a0-a2be-56094a995dfa</zipfile_location>
+		<zipfile_datetime>20230930_063710</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-09-30T06:37:10Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4068234830</number>
+		<title>1R76K83I</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=a8c4cf60-73d2-4750-a99b-56406cbd3dcf</zipfile_location>
+		<zipfile_datetime>20211005_110717</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-10-05T11:07:17Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1101268592</number>
+		<title>2P7TI099</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=1ba2ba2a-66bb-429d-bb2f-56cf7f057fb6</zipfile_location>
+		<zipfile_datetime>20211230_095620</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-12-30T09:56:20Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2178977356</number>
+		<title>1W7MA190</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=00d843ef-0d9d-4850-bc6e-571cfdf39d19</zipfile_location>
+		<zipfile_datetime>20210512_145216</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-12T14:52:16Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1678805593</number>
+		<title>3R7D0332</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=959dd9ac-7a38-48f2-9888-572361c54504</zipfile_location>
+		<zipfile_datetime>20230919_063547</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-09-19T06:35:47Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2260500037</number>
+		<title>9D7EL730</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=f3b5dbae-bdbd-43fd-aee8-5725164d187a</zipfile_location>
+		<zipfile_datetime>20230331_063525</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-03-31T06:35:25Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2222696356</number>
+		<title>1W7OD660</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=f8e383c3-cc70-44f8-94eb-5741036b1b1c</zipfile_location>
+		<zipfile_datetime>20210205_120411</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-02-05T12:04:11Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1394661680</number>
+		<title>1W7MA280</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=035d9810-97cd-4d1b-823e-57578668cd8b</zipfile_location>
+		<zipfile_datetime>20210512_145217</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-12T14:52:17Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2142720620</number>
+		<title>1W7HO070</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=146b5fe5-211e-49e1-89a1-57a3fee38818</zipfile_location>
+		<zipfile_datetime>20201016_162828</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-16T16:28:28Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2374319301</number>
+		<title>1W7EL510</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=f2907ee0-f755-493f-a207-57ae701d8426</zipfile_location>
+		<zipfile_datetime>20230207_063519</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-02-07T06:35:19Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2449779331</number>
+		<title>3R7BM008</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=3c942f23-634d-4b8a-9aa0-57f60aa6b1c3</zipfile_location>
+		<zipfile_datetime>20220326_095422</zipfile_datetime>
+		<zipfile_datetime_iso8601>2022-03-26T09:54:22Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2615460093</number>
+		<title>1W7OD630</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=d3a974a8-0d02-438f-85db-580b3ebd5070</zipfile_location>
+		<zipfile_datetime>20210205_120410</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-02-05T12:04:10Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>801307925</number>
+		<title>2WBDHLVH</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=f2f2ec5b-e231-4480-95bd-58352803b1eb</zipfile_location>
+		<zipfile_datetime>20240830_063636</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-30T06:36:36Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1269917642</number>
+		<title>1R7RM003</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=529c7dea-3382-4220-929b-587660d39962</zipfile_location>
+		<zipfile_datetime>20210903_152951</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T15:29:51Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2408550402</number>
+		<title>1W7EL260</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=e770a279-d36a-4f5f-a90a-58bf8138b6da</zipfile_location>
+		<zipfile_datetime>20240227_063719</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:19Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3435580917</number>
+		<title>BE7EV004</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=9eb5002d-8e76-4e39-987d-58d5ea01b69c</zipfile_location>
+		<zipfile_datetime>20240820_113045</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-20T11:30:45Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2133862480</number>
+		<title>2W7D2150</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=0f1c0181-0fbc-4b75-9a80-58e6641ef45e</zipfile_location>
+		<zipfile_datetime>20240501_063819</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-05-01T06:38:19Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3919405516</number>
+		<title>1W7RH210</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=d561c9c9-7954-4ec4-b87f-58ecd34b0e01</zipfile_location>
+		<zipfile_datetime>20201022_171711</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-22T17:17:11Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2013139157</number>
+		<title>3R7D0278</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=ecb4a66c-4dfa-4fc4-a4e8-58ff901ea070</zipfile_location>
+		<zipfile_datetime>20240613_063600</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-06-13T06:36:00Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2129823890</number>
+		<title>7V7ZEEK1</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=abcd8cdf-6c04-407b-9629-590b2b3cd127</zipfile_location>
+		<zipfile_datetime>20210701_112120</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:21:20Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1969246209</number>
+		<title>1W7RH240</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=8e006ca8-34e5-4411-9075-5993230d93fd</zipfile_location>
+		<zipfile_datetime>20201022_171711</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-22T17:17:11Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1876514147</number>
+		<title>2P7D1057</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=a09c7143-172e-456e-8d82-59cd98cc108f</zipfile_location>
+		<zipfile_datetime>20230408_063535</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-08T06:35:35Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3802739703</number>
+		<title>3RB4DC01</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=fbfe3335-89be-41ed-a545-59f5c61112d4</zipfile_location>
+		<zipfile_datetime>20230919_063548</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-09-19T06:35:48Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>926025856</number>
+		<title>2P7D1424</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=7c1d80ba-b18c-4a1d-b026-5a25ff67152f</zipfile_location>
+		<zipfile_datetime>20230408_063539</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-08T06:35:39Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2295792563</number>
+		<title>1W7DE006</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=acb1a3e3-37bc-4c45-b16f-5a46fb12439b</zipfile_location>
+		<zipfile_datetime>20240227_063706</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:06Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2582315774</number>
+		<title>1W7SL015</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=93a183ca-de88-458a-9089-5a4e2640d51d</zipfile_location>
+		<zipfile_datetime>20231011_063505</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-10-11T06:35:05Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1457636286</number>
+		<title>1W7D2230</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=61ffd3ce-5090-4b54-ab18-5aa910905727</zipfile_location>
+		<zipfile_datetime>20220611_063522</zipfile_datetime>
+		<zipfile_datetime_iso8601>2022-06-11T06:35:22Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2164806899</number>
+		<title>1W7RH830</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=5f5b71fc-19d7-4575-ae15-5ab4c40bfaca</zipfile_location>
+		<zipfile_datetime>20230413_063525</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-13T06:35:25Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1360706204</number>
+		<title>2D7D1709</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=6dc4d356-0438-4c33-a0f4-5b4057ec9938</zipfile_location>
+		<zipfile_datetime>20210908_095508</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:08Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2217493750</number>
+		<title>9DBEL740</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=970bfc90-6139-4580-9438-5b6b1d83e718</zipfile_location>
+		<zipfile_datetime>20230331_063527</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-03-31T06:35:27Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2927659152</number>
+		<title>1W7EL150</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=e142e9f6-be9a-4306-9fe4-5bdbcd9dcee5</zipfile_location>
+		<zipfile_datetime>20240227_063718</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:18Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2540383266</number>
+		<title>2P7D0876</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=db4f270f-eb81-4743-b87b-5be086860971</zipfile_location>
+		<zipfile_datetime>20230408_063534</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-08T06:35:34Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2009110956</number>
+		<title>2WBD2220</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=a267a8fd-8265-4675-b75a-5bed4729c6d4</zipfile_location>
+		<zipfile_datetime>20230930_063710</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-09-30T06:37:10Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>700711083</number>
+		<title>7V7SPIKA</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=1ea6a98b-4ba2-4fe5-ab99-5c1c3439036d</zipfile_location>
+		<zipfile_datetime>20210701_112119</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:21:19Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>958041457</number>
+		<title>3B7D0458</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=5f20f5c6-c5c1-41d7-bf8b-5c36ab08a073</zipfile_location>
+		<zipfile_datetime>20240829_063722</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-29T06:37:22Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4041344479</number>
+		<title>1H7D1660</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=5bb9f23f-944f-4a59-9db4-5c8ca5089b49</zipfile_location>
+		<zipfile_datetime>20230712_063525</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-07-12T06:35:25Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2418485633</number>
+		<title>1W7KK003</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=629e4b4d-20cf-4fd0-b897-5ca2f44faaaa</zipfile_location>
+		<zipfile_datetime>20210503_145616</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-03T14:56:16Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2004498918</number>
+		<title>1W7RH590</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=49dacfad-aaf6-4470-9eaf-5cc6deadf3c9</zipfile_location>
+		<zipfile_datetime>20240227_063713</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:13Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1061814547</number>
+		<title>1W7RH330</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=b8001018-88bd-4643-a021-5ccaebab4fa9</zipfile_location>
+		<zipfile_datetime>20240227_063708</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:08Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2040613879</number>
+		<title>1W7UH010</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=5ac94bc9-954f-4077-8376-5d3d19bf9c3c</zipfile_location>
+		<zipfile_datetime>20230804_063502</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-08-04T06:35:02Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3254807410</number>
+		<title>3R7DCC01</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=e06dd386-a088-4722-b198-5d44872a23fe</zipfile_location>
+		<zipfile_datetime>20220423_095652</zipfile_datetime>
+		<zipfile_datetime_iso8601>2022-04-23T09:56:52Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3004459394</number>
+		<title>1W7WE270</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=9d50c151-08e3-4093-a873-5d597b75f020</zipfile_location>
+		<zipfile_datetime>20210908_095538</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:38Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1699939776</number>
+		<title>3R7D0168</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=842c6742-ccb4-47d7-9841-5d6671ae5443</zipfile_location>
+		<zipfile_datetime>20240824_063611</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-24T06:36:11Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2394381203</number>
+		<title>1W7NE150</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=021d0155-56bb-44ec-a0cd-5d6f93dd08b4</zipfile_location>
+		<zipfile_datetime>20210914_095428</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-14T09:54:28Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3732174845</number>
+		<title>4V5019DE</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=a48d4fc5-e48d-490b-ad54-5d71854cb897</zipfile_location>
+		<zipfile_datetime>20201022_171706</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-22T17:17:06Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>606997104</number>
+		<title>1H7TI470</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=a4417f8e-e27a-492d-8e7d-5dec2d307610</zipfile_location>
+		<zipfile_datetime>20211012_145459</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-10-12T14:54:59Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1603061327</number>
+		<title>3R7D0324</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=e181007f-0d68-4668-b067-5e16aa711bc4</zipfile_location>
+		<zipfile_datetime>20230919_063547</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-09-19T06:35:47Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4189677456</number>
+		<title>1W7HO050</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=7ef50be5-fb69-4788-b6e3-5e228cf64cd7</zipfile_location>
+		<zipfile_datetime>20201016_162828</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-16T16:28:28Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3082175604</number>
+		<title>7V7BEVE2</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=a0f008b8-8058-4e0b-9317-5e4d3d3a902d</zipfile_location>
+		<zipfile_datetime>20210701_111429</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:14:29Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>10520280</number>
+		<title>9DBEL726</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=6750cfed-c27e-49ca-a719-5e5238ae6109</zipfile_location>
+		<zipfile_datetime>20230331_063527</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-03-31T06:35:27Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3954272096</number>
+		<title>1R7MK029</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=70f4ca40-2723-46ba-b24e-5eecb2c2a858</zipfile_location>
+		<zipfile_datetime>20210903_150939</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T15:09:39Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3750744993</number>
+		<title>1W7MO060</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=b4b8f8f3-11a9-4e07-b64a-5f5171d489e8</zipfile_location>
+		<zipfile_datetime>20210908_095516</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:16Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>693300092</number>
+		<title>3R7D0016</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=7a5c7a9c-cdd6-4173-917a-5f5a8b4aaa8e</zipfile_location>
+		<zipfile_datetime>20240613_063601</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-06-13T06:36:01Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3208581382</number>
+		<title>7V7BZS07</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=47f0577f-42b1-42fc-8c9c-5f64e23b3d88</zipfile_location>
+		<zipfile_datetime>20210701_110750</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:07:50Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3553634233</number>
+		<title>1W7RH800</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=1be30e92-3bd6-4c44-b51f-5fcde3e550d3</zipfile_location>
+		<zipfile_datetime>20210503_145646</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-03T14:56:46Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>18651556</number>
+		<title>1R7NR916</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=cc850acb-28f9-4fe2-9217-5fd2a8eaff53</zipfile_location>
+		<zipfile_datetime>20210903_152300</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T15:23:00Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4118871253</number>
+		<title>1W7SO120</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=10450426-d430-4b96-844e-5ff77d83bd41</zipfile_location>
+		<zipfile_datetime>20211016_095517</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-10-16T09:55:17Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>903162921</number>
+		<title>1R7YM001</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=0108a750-7721-49f6-aa55-60141a61333f</zipfile_location>
+		<zipfile_datetime>20210903_123034</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T12:30:34Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4031457109</number>
+		<title>4V5SAO14</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=0b7858e6-021c-45cf-af88-602cbfad8317</zipfile_location>
+		<zipfile_datetime>20201022_171713</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-22T17:17:13Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>126970016</number>
+		<title>1R7MWK01</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=d306683b-e929-4f1f-afe1-603952beabfd</zipfile_location>
+		<zipfile_datetime>20210903_170008</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T17:00:08Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2179399232</number>
+		<title>1W7EL360</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=945ab979-031d-46cb-8628-603a81575b3f</zipfile_location>
+		<zipfile_datetime>20240227_063721</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:21Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>483686828</number>
+		<title>3R7D0658</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=c06e9d17-e475-4499-9be9-604723af281b</zipfile_location>
+		<zipfile_datetime>20240821_063617</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-21T06:36:17Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1774855533</number>
+		<title>7W7BOSC1</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=7d0d9f26-0c99-42d1-a6ef-60af91c6a53d</zipfile_location>
+		<zipfile_datetime>20181018_211038</zipfile_datetime>
+		<zipfile_datetime_iso8601>2018-10-18T21:10:38Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3560812861</number>
+		<title>3R7D0228</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=58816d25-9287-429b-891e-60cd5cbf4d5d</zipfile_location>
+		<zipfile_datetime>20240613_063559</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-06-13T06:35:59Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>937748936</number>
+		<title>3R7D0889</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=e12f80a4-d1cb-40c1-8ae3-61176812ccea</zipfile_location>
+		<zipfile_datetime>20201209_103450</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-12-09T10:34:50Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3122232629</number>
+		<title>2W7D2050</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=f1988391-f6b5-40c7-b76f-611906f55943</zipfile_location>
+		<zipfile_datetime>20230930_063700</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-09-30T06:37:00Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2172128362</number>
+		<title>4V5SAO11</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=5523f573-11a1-4d56-bb69-618307790801</zipfile_location>
+		<zipfile_datetime>20201022_171713</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-22T17:17:13Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3814482979</number>
+		<title>1R7AM252</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=ff838b28-e99d-454f-a5f5-623f4e90b472</zipfile_location>
+		<zipfile_datetime>20210313_183526</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-03-13T18:35:26Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3467153802</number>
+		<title>1W7D2410</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=f6012e15-eca6-4d10-9ef0-6259575e4a51</zipfile_location>
+		<zipfile_datetime>20220611_063524</zipfile_datetime>
+		<zipfile_datetime_iso8601>2022-06-11T06:35:24Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3265616352</number>
+		<title>3R7D0289</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=e1d6eab2-9a9d-4249-a405-625a23125e3a</zipfile_location>
+		<zipfile_datetime>20240613_063600</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-06-13T06:36:00Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1707046888</number>
+		<title>1W7ML060</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=48224262-288b-4cb7-a841-627dd5b0b342</zipfile_location>
+		<zipfile_datetime>20210908_095528</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:28Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>71401904</number>
+		<title>1H7TI220</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=9b983fc7-a79e-497c-afb3-628e8a1d62b8</zipfile_location>
+		<zipfile_datetime>20211012_145453</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-10-12T14:54:53Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>202932866</number>
+		<title>1R7WZ007</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=58cf5488-1588-456f-8041-62a56b723fe7</zipfile_location>
+		<zipfile_datetime>20210903_110003</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T11:00:03Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>800667468</number>
+		<title>4V5010DE</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=f9a45a52-ebdc-4888-b3d8-62dc4851a85c</zipfile_location>
+		<zipfile_datetime>20201022_171704</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-22T17:17:04Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1388639312</number>
+		<title>1W7OD610</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=4bef0efb-42a4-49fa-8892-6304f032d3d4</zipfile_location>
+		<zipfile_datetime>20210205_120409</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-02-05T12:04:09Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1200377413</number>
+		<title>1W7OD580</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=1b9fdb39-29f2-45a4-aaf6-638648ca7070</zipfile_location>
+		<zipfile_datetime>20210205_120407</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-02-05T12:04:07Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1631313425</number>
+		<title>7V7PLDU1</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=70ec85c4-e75c-4118-ae59-640fcf963100</zipfile_location>
+		<zipfile_datetime>20210701_112116</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:21:16Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>418299821</number>
+		<title>1W7SO080</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=bc45997f-3936-43fd-a0cd-64423d92a150</zipfile_location>
+		<zipfile_datetime>20211016_095514</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-10-16T09:55:14Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>735782399</number>
+		<title>1R7HD001</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=7c4b707a-be73-4271-9339-646ffc8fb9ec</zipfile_location>
+		<zipfile_datetime>20210903_142523</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T14:25:23Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1778811132</number>
+		<title>3R7D0900</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=5bd9b984-05b4-40d8-9628-64a758bba7d3</zipfile_location>
+		<zipfile_datetime>20201209_103450</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-12-09T10:34:50Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2497654683</number>
+		<title>2WBDHKOR</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=99719cf0-359d-464b-a9ea-64d6ef836715</zipfile_location>
+		<zipfile_datetime>20240403_063652</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-04-03T06:36:52Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1868536974</number>
+		<title>1W7RH270</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=7b6ac447-dc6c-406b-bdd4-64facd1e325c</zipfile_location>
+		<zipfile_datetime>20201022_171711</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-22T17:17:11Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4091400981</number>
+		<title>2P7TI060</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=b2f33ba8-e0c6-44ea-afa0-65465b030309</zipfile_location>
+		<zipfile_datetime>20230408_063542</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-08T06:35:42Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2924537631</number>
+		<title>2P7SA097</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=75a8cd72-8a95-4ffe-9c34-65babb8e57ce</zipfile_location>
+		<zipfile_datetime>20230413_063522</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-13T06:35:22Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2250699088</number>
+		<title>1W7OD650</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=9c144228-7ded-4542-92c1-65d35610c381</zipfile_location>
+		<zipfile_datetime>20210205_120410</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-02-05T12:04:10Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3141755614</number>
+		<title>3R7SFG08</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=e2492a69-c182-41f1-acb9-66109dda62f7</zipfile_location>
+		<zipfile_datetime>20201016_162825</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-16T16:28:25Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1997259191</number>
+		<title>1W7RH290</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=24a04f16-25ab-403e-8192-6628a5ff01b8</zipfile_location>
+		<zipfile_datetime>20201022_171711</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-22T17:17:11Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>701731202</number>
+		<title>2WBD1903</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=1ded7135-9266-4c44-b0cd-66379b089955</zipfile_location>
+		<zipfile_datetime>20240614_063721</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-06-14T06:37:21Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>310862674</number>
+		<title>2R71022S</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=e8b3d88c-0588-42f5-b96e-66388c0195f7</zipfile_location>
+		<zipfile_datetime>20210126_112612</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-01-26T11:26:12Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2395994945</number>
+		<title>1H7TI210</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=55798d12-39e8-4f7c-8183-6688ebf1d7aa</zipfile_location>
+		<zipfile_datetime>20211012_145451</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-10-12T14:54:51Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4128017589</number>
+		<title>1W7EL320</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=1902de54-bf8f-4d6a-a9ea-668c2f921f9f</zipfile_location>
+		<zipfile_datetime>20240227_063721</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:21Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2893017268</number>
+		<title>1W7DHK04</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=a4134dc4-d686-40a8-b40e-668d4d3017dc</zipfile_location>
+		<zipfile_datetime>20210503_145609</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-03T14:56:09Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>724207500</number>
+		<title>1R7WZ002</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=1259d4be-1bc0-4d0c-9e61-673d7fbcba62</zipfile_location>
+		<zipfile_datetime>20210903_105116</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T10:51:16Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1902772930</number>
+		<title>1W7RH760</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=32366c99-1376-4379-a052-6742d2ec4bb5</zipfile_location>
+		<zipfile_datetime>20210503_145645</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-03T14:56:45Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1350834633</number>
+		<title>1W7EL250</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=7efe15f0-1a66-4372-9900-677acb460a27</zipfile_location>
+		<zipfile_datetime>20240227_063719</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:19Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3352362581</number>
+		<title>5C7DR016</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=82593249-bc85-4ec7-b1d4-6836f0b8e5d1</zipfile_location>
+		<zipfile_datetime>20210326_132846</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-03-26T13:28:46Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1718899862</number>
+		<title>1W7RH850</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=8a873427-cb2f-44a7-a043-68410240084e</zipfile_location>
+		<zipfile_datetime>20230413_063525</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-13T06:35:25Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>645631804</number>
+		<title>7V7DEND1</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=4aac7c3b-0c74-49eb-9e84-6850c17da0b2</zipfile_location>
+		<zipfile_datetime>20210701_111123</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:11:23Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1159430272</number>
+		<title>3R7D0973</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=b08bc9b5-d2f3-4abe-b9ea-68584c1f4bf5</zipfile_location>
+		<zipfile_datetime>20201209_103452</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-12-09T10:34:52Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1157128149</number>
+		<title>1W7RHK03</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=540ec846-8cf0-4cff-9d6d-68c103f35317</zipfile_location>
+		<zipfile_datetime>20240227_063707</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:07Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4229153256</number>
+		<title>2R71028S</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=5500d8dd-c010-42de-8f34-68d0cffecd43</zipfile_location>
+		<zipfile_datetime>20210126_112613</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-01-26T11:26:13Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1970171131</number>
+		<title>1H7D1670</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=5a98cbf9-d77c-42aa-80ae-68d23141949d</zipfile_location>
+		<zipfile_datetime>20230712_063525</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-07-12T06:35:25Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2665976513</number>
+		<title>2WBD2040</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=ca5e36b7-7173-4f94-90d2-68dd1eff9faa</zipfile_location>
+		<zipfile_datetime>20230929_063649</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-09-29T06:36:49Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1955866085</number>
+		<title>2P7D0906</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=ca4d5866-8f69-4df3-9066-690012a1cd49</zipfile_location>
+		<zipfile_datetime>20230408_063534</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-08T06:35:34Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>840199870</number>
+		<title>3R7D0156</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=4503860e-30aa-484b-a1f4-690bdb5522f0</zipfile_location>
+		<zipfile_datetime>20240824_063611</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-24T06:36:11Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>885898895</number>
+		<title>1W7HVK02</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=7e9d9352-ae1e-4f72-b5e6-694a040dfa78</zipfile_location>
+		<zipfile_datetime>20230804_063501</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-08-04T06:35:01Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1936452072</number>
+		<title>BE8PK001</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=7221f3a2-7c5e-4498-90c4-69a9efcc5392</zipfile_location>
+		<zipfile_datetime>20230808_100220</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-08-08T10:02:20Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>628705677</number>
+		<title>1W7SO110</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=bf1b608a-762a-4d43-9827-69bac8f6de47</zipfile_location>
+		<zipfile_datetime>20211016_095517</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-10-16T09:55:17Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3716980532</number>
+		<title>1W7RH220</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=4cf0972a-59ef-401d-9d8f-6a3bc6ca4723</zipfile_location>
+		<zipfile_datetime>20201022_171711</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-22T17:17:11Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>719922709</number>
+		<title>7V7MOER2</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=2f04b7ff-6ec0-48fe-9df9-6a4225eaf224</zipfile_location>
+		<zipfile_datetime>20210701_110751</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:07:51Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4216691379</number>
+		<title>2WBD2141</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=5dad3f5a-5b7a-4269-ba0a-6a5d83f1c119</zipfile_location>
+		<zipfile_datetime>20240830_063635</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-30T06:36:35Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1192384835</number>
+		<title>1W7ML270</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=9714a169-6f48-40b2-9b17-6a6eacdd1cfb</zipfile_location>
+		<zipfile_datetime>20210908_095535</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:35Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3836194281</number>
+		<title>1R7WZ008</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=1dcdc3be-a85b-42e4-b41f-6ad0ccf0274a</zipfile_location>
+		<zipfile_datetime>20210903_110115</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T11:01:15Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3525388990</number>
+		<title>4V5MOS06</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=8b3205ed-bcf0-41a0-bbd1-6ae9213ea9e9</zipfile_location>
+		<zipfile_datetime>20221201_181902</zipfile_datetime>
+		<zipfile_datetime_iso8601>2022-12-01T18:19:02Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2947314701</number>
+		<title>3R7D0713</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=84bfeb0d-79ca-42cc-8ecf-6b23caa6193a</zipfile_location>
+		<zipfile_datetime>20240821_063619</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-21T06:36:19Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2433493748</number>
+		<title>7V7DEKW2</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=f2dcefce-a47f-40b0-949f-6b71f6da1ee1</zipfile_location>
+		<zipfile_datetime>20210701_111257</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:12:57Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3887115892</number>
+		<title>2WBD1901</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=ef1ccccc-5d27-4931-b35a-6b7c1e41bf49</zipfile_location>
+		<zipfile_datetime>20240614_063720</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-06-14T06:37:20Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1649045557</number>
+		<title>2R71007N</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=d169f55e-3a32-45ff-902a-6beaeb77f072</zipfile_location>
+		<zipfile_datetime>20210126_112612</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-01-26T11:26:12Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>201301302</number>
+		<title>3R7D0991</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=2295f226-cd72-4c7e-8841-6c0dfcfd3eba</zipfile_location>
+		<zipfile_datetime>20201209_103452</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-12-09T10:34:52Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1202054144</number>
+		<title>1R7MA017</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=86450de7-9d9b-4225-abe7-6c2736af4855</zipfile_location>
+		<zipfile_datetime>20210607_103627</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-06-07T10:36:27Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3883709616</number>
+		<title>4V5012DE</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=87b3e649-ce2c-488e-98db-6c8551583391</zipfile_location>
+		<zipfile_datetime>20201022_171705</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-22T17:17:05Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2475387687</number>
+		<title>2P7TI040</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=1fe4e683-6fab-496e-a712-6c9f40a376eb</zipfile_location>
+		<zipfile_datetime>20230408_063542</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-08T06:35:42Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3387653746</number>
+		<title>1W7RH470</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=8bdc731b-b9a3-4af2-8d12-6ce4571ff05a</zipfile_location>
+		<zipfile_datetime>20240227_063710</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:10Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2237805005</number>
+		<title>3R7D0732</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=f963917e-191a-4111-b0bf-6cee00e12ab4</zipfile_location>
+		<zipfile_datetime>20240821_063619</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-21T06:36:19Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2573095431</number>
+		<title>1W7EL230</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=c5e82f2d-9b3c-47fa-8c2b-6d1648ba61ed</zipfile_location>
+		<zipfile_datetime>20240227_063719</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:19Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3627841211</number>
+		<title>1W7WE340</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=ac3f74f5-c56b-4975-b7e1-6d54b6602275</zipfile_location>
+		<zipfile_datetime>20210908_095540</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:40Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4003444629</number>
+		<title>2WBDHLWH</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=9922e12a-3572-4b8c-a16e-6d8393b3a941</zipfile_location>
+		<zipfile_datetime>20240830_063637</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-30T06:36:37Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2207385441</number>
+		<title>1W7ML090</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=9bd18956-9c0c-4c07-aa73-6d96962b46ab</zipfile_location>
+		<zipfile_datetime>20210908_095528</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:28Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1301838896</number>
+		<title>7V7LEIE2</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=53c4dad8-bddb-45a4-851a-6dab0f928624</zipfile_location>
+		<zipfile_datetime>20210701_112113</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:21:13Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2562262168</number>
+		<title>1W7ML300</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=a1b0eadc-ff0a-48aa-b15e-6e4447942d15</zipfile_location>
+		<zipfile_datetime>20210908_095535</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:35Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>888811297</number>
+		<title>1W7EL410</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=1cc419ef-5538-4fc5-a14b-6ea585eae263</zipfile_location>
+		<zipfile_datetime>20240227_063722</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:22Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1087676422</number>
+		<title>2WBD2130</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=edeb0b01-e3a2-4571-9365-6f809c4142e9</zipfile_location>
+		<zipfile_datetime>20240830_063634</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-30T06:36:34Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>82140478</number>
+		<title>4V5001DE</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=a4bfdd93-92af-4c26-8a85-6fb2d8658299</zipfile_location>
+		<zipfile_datetime>20201022_171703</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-22T17:17:03Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>82621786</number>
+		<title>1W7BSK01</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=baf71186-9cc2-4a5d-89e3-6ffafd476d8a</zipfile_location>
+		<zipfile_datetime>20221103_063447</zipfile_datetime>
+		<zipfile_datetime_iso8601>2022-11-03T06:34:47Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2909616537</number>
+		<title>1W7D2240</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=50d2ddbc-cf0e-45df-915f-706ab095377c</zipfile_location>
+		<zipfile_datetime>20220611_063523</zipfile_datetime>
+		<zipfile_datetime_iso8601>2022-06-11T06:35:23Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1510972557</number>
+		<title>1H7TI420</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=17529ccd-de34-4c33-a157-708ea0199521</zipfile_location>
+		<zipfile_datetime>20211012_145458</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-10-12T14:54:58Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1302690231</number>
+		<title>1R7PK871</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=4ec17a9d-8fa9-4f77-ad77-70a64be97a8e</zipfile_location>
+		<zipfile_datetime>20210903_155513</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T15:55:13Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>410899898</number>
+		<title>1H7D1430</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=1c9f8a69-bb67-4e2c-9415-70d5e9326b19</zipfile_location>
+		<zipfile_datetime>20230712_063521</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-07-12T06:35:21Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1301786672</number>
+		<title>1R7HV001</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=623cee4b-fa93-496a-9ef5-70d7d9f427c9</zipfile_location>
+		<zipfile_datetime>20210903_134332</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T13:43:32Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2814195797</number>
+		<title>1W7MA350</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=1b01ccbc-ec15-4760-bfef-70ec4794ca63</zipfile_location>
+		<zipfile_datetime>20210512_145218</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-12T14:52:18Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>801916967</number>
+		<title>7V7ZEEK3</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=17e780d0-c4db-470d-9e7e-70efa9d82109</zipfile_location>
+		<zipfile_datetime>20210701_112121</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:21:21Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1552890135</number>
+		<title>1W7DE009</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=f2cbb369-1f7d-4222-b5d2-7115f763d711</zipfile_location>
+		<zipfile_datetime>20210503_145610</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-03T14:56:10Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>108775870</number>
+		<title>3R7DBB08</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=bed22e84-13e7-4fb8-8acb-711a66643906</zipfile_location>
+		<zipfile_datetime>20230214_063449</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-02-14T06:34:49Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>126110573</number>
+		<title>3R7DBB03</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=8c2376d8-0d79-4fc4-ae31-7159f2703024</zipfile_location>
+		<zipfile_datetime>20230214_063448</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-02-14T06:34:48Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>615616536</number>
+		<title>2WBD2161</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=04b11bd1-ee55-486c-adcb-71cc03719d8e</zipfile_location>
+		<zipfile_datetime>20231025_063504</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-10-25T06:35:04Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1630803987</number>
+		<title>1R7MD001</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=f3725abb-fd9e-45ca-9b10-71d507c1d0db</zipfile_location>
+		<zipfile_datetime>20210903_165736</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T16:57:36Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2216171174</number>
+		<title>2D7DK000</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=a23a5e77-02be-47c2-82fb-71e89603b6d5</zipfile_location>
+		<zipfile_datetime>20210908_095511</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:11Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2920089734</number>
+		<title>3R7D0920</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=471d9875-bf46-40be-bd3c-721d4b032dca</zipfile_location>
+		<zipfile_datetime>20201209_103451</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-12-09T10:34:51Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3042247598</number>
+		<title>1W7DE007</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=59c32019-d34d-406e-ab49-724b02d9ea5c</zipfile_location>
+		<zipfile_datetime>20240227_063706</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:06Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4021206782</number>
+		<title>1R7OM991</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=508afdd5-6b51-497f-af45-7278c0772e5d</zipfile_location>
+		<zipfile_datetime>20210903_151817</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T15:18:17Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3144969668</number>
+		<title>1W7MO170</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=70bb950c-7905-40c5-a8d5-7296e48002fd</zipfile_location>
+		<zipfile_datetime>20210908_095521</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:21Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>789153042</number>
+		<title>1W7ML310</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=e6493304-884c-4e72-98e9-73156e733901</zipfile_location>
+		<zipfile_datetime>20210908_095536</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:36Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>125118571</number>
+		<title>2WBD1930</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=2b260c35-9f7b-4421-9a09-7387fc980a9a</zipfile_location>
+		<zipfile_datetime>20240403_063651</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-04-03T06:36:51Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1575249771</number>
+		<title>1W7SL075</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=36167479-dac2-4119-8a35-740ab29a6dab</zipfile_location>
+		<zipfile_datetime>20231011_063506</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-10-11T06:35:06Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3987969276</number>
+		<title>1W7SO090</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=1ed49094-9523-40b4-84f5-74314d370106</zipfile_location>
+		<zipfile_datetime>20220611_063526</zipfile_datetime>
+		<zipfile_datetime_iso8601>2022-06-11T06:35:26Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3878317891</number>
+		<title>3R7DBB01</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=d132890e-687f-4ad2-a066-74374929728e</zipfile_location>
+		<zipfile_datetime>20230214_063448</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-02-14T06:34:48Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2042781360</number>
+		<title>1W7MA250</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=75da9432-4ba0-4ecc-bcba-744944a692ab</zipfile_location>
+		<zipfile_datetime>20210512_145217</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-12T14:52:17Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3147645063</number>
+		<title>2WBD2070</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=0b130411-3e62-4542-8e61-74c779e89bc2</zipfile_location>
+		<zipfile_datetime>20230929_063650</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-09-29T06:36:50Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>833883001</number>
+		<title>2P7SA119</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=002064e3-a8b8-4857-b19f-74d72c2521f2</zipfile_location>
+		<zipfile_datetime>20230413_063522</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-13T06:35:22Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>777861654</number>
+		<title>1R7YM008</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=360f5f42-f289-409c-a4c1-74eb2faa0be8</zipfile_location>
+		<zipfile_datetime>20210903_123858</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T12:38:58Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1011874270</number>
+		<title>1W7MA270</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=265e44de-a1bc-4a01-bb68-75b5fc9c9e56</zipfile_location>
+		<zipfile_datetime>20210512_145217</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-12T14:52:17Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3001768825</number>
+		<title>1W7DE022</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=d989897a-deb2-44ba-a23d-760c6b7928cd</zipfile_location>
+		<zipfile_datetime>20210503_145616</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-03T14:56:16Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1755075834</number>
+		<title>1W7MD000</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=01d540db-8da5-4848-9e5b-76855840dec7</zipfile_location>
+		<zipfile_datetime>20210512_145219</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-12T14:52:19Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1641541208</number>
+		<title>1W7MA000</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=478fa357-4d90-4e81-9f73-76857d16a2c4</zipfile_location>
+		<zipfile_datetime>20210512_145207</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-12T14:52:07Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>249730692</number>
+		<title>2D7D1791</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=24a6ae85-895f-4e70-97b3-76d0e7ff6c9e</zipfile_location>
+		<zipfile_datetime>20210908_095510</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:10Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>864589932</number>
+		<title>3R7BM002</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=28601014-34aa-44b5-8b92-76e11052d8c1</zipfile_location>
+		<zipfile_datetime>20220326_095417</zipfile_datetime>
+		<zipfile_datetime_iso8601>2022-03-26T09:54:17Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4285412782</number>
+		<title>2WBD2190</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=3615feae-6743-4624-b903-76ef4a76b692</zipfile_location>
+		<zipfile_datetime>20240131_063610</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-01-31T06:36:10Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3441693816</number>
+		<title>4V5MOS03</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=594a75bc-a83a-4ac3-bbba-770f0756119d</zipfile_location>
+		<zipfile_datetime>20221201_181742</zipfile_datetime>
+		<zipfile_datetime_iso8601>2022-12-01T18:17:42Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2057774552</number>
+		<title>2D7D1762</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=e869771b-f891-47ae-9895-77b2e56558f4</zipfile_location>
+		<zipfile_datetime>20210908_095510</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:10Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>67818273</number>
+		<title>1H7D1530</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=5e08a734-2ed6-4a87-b08e-77b54cd2d1b3</zipfile_location>
+		<zipfile_datetime>20230712_063523</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-07-12T06:35:23Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2920160201</number>
+		<title>1W7MD030</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=7a7367b8-28a9-4d42-90a0-7853b8f90642</zipfile_location>
+		<zipfile_datetime>20210512_145219</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-12T14:52:19Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>466394144</number>
+		<title>9D7EL890</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=c43c0e31-9908-4ffb-8d0a-787d601d31db</zipfile_location>
+		<zipfile_datetime>20230331_063530</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-03-31T06:35:30Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2720365856</number>
+		<title>1W7DE016</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=b75557c1-6157-48c9-ba72-78933d406628</zipfile_location>
+		<zipfile_datetime>20210503_145611</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-03T14:56:11Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>444578567</number>
+		<title>1W7RH600</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=c6ff54b3-abdc-4b8f-a164-78a6ec8d5c7e</zipfile_location>
+		<zipfile_datetime>20240227_063713</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:13Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2480807966</number>
+		<title>1W7MA130</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=0a4dae2c-1661-419b-8d86-78c47a8e18a1</zipfile_location>
+		<zipfile_datetime>20210512_145215</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-12T14:52:15Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4059716547</number>
+		<title>3R7D0721</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=31bcb1d0-d720-4794-85a3-78ec5a8ec5d3</zipfile_location>
+		<zipfile_datetime>20240821_063619</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-21T06:36:19Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1023618387</number>
+		<title>1W7EL040</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=465157f9-c740-4578-87b9-7903896e97a4</zipfile_location>
+		<zipfile_datetime>20240227_063716</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:16Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3367506049</number>
+		<title>3R7D0069</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=45ea0407-83be-4adf-8920-79231c272071</zipfile_location>
+		<zipfile_datetime>20240824_063610</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-24T06:36:10Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>117213787</number>
+		<title>1W7RH180</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=449301f8-c9a2-4dc7-abcd-792768bbedc6</zipfile_location>
+		<zipfile_datetime>20201022_171711</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-22T17:17:11Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>122340615</number>
+		<title>1W7DHK01</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=2a3ac072-9178-495b-9b55-79358756e738</zipfile_location>
+		<zipfile_datetime>20210503_145608</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-03T14:56:08Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1240711411</number>
+		<title>1R7YM015</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=bb3fa82f-c1c5-4b8f-8494-79958e4eac98</zipfile_location>
+		<zipfile_datetime>20210903_124409</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T12:44:09Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2777335187</number>
+		<title>4V5MOS11</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=54fc3bad-d99a-42b8-b171-79b86a987ee1</zipfile_location>
+		<zipfile_datetime>20221201_182119</zipfile_datetime>
+		<zipfile_datetime_iso8601>2022-12-01T18:21:19Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3823992202</number>
+		<title>1H7TI350</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=8afcb7c8-f7c9-446c-81ed-79fed4b7c0a9</zipfile_location>
+		<zipfile_datetime>20211012_145456</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-10-12T14:54:56Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1318324605</number>
+		<title>4V5SAO06</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=5f451e46-5232-4d41-b7bd-7a0aa2ff8d66</zipfile_location>
+		<zipfile_datetime>20201022_171712</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-22T17:17:12Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1583334083</number>
+		<title>9D7EL745</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=cec025f4-5b1d-44ee-96ee-7af2b5e50b45</zipfile_location>
+		<zipfile_datetime>20230331_063526</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-03-31T06:35:26Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>355223194</number>
+		<title>1W7WOD01</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=1afb4356-6952-4a83-9e63-7b11d8990201</zipfile_location>
+		<zipfile_datetime>20210205_120406</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-02-05T12:04:06Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1786217691</number>
+		<title>1R7WZ006</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=ea02dfa3-c5a3-4e2d-8fee-7b125981abea</zipfile_location>
+		<zipfile_datetime>20210903_105900</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T10:59:00Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1765819976</number>
+		<title>9D7EL800</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=31cda931-fa82-44d9-b710-7b19ffc6ad7c</zipfile_location>
+		<zipfile_datetime>20230331_063528</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-03-31T06:35:28Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2434098624</number>
+		<title>1R7HY008</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=265b7925-8e10-41e7-ba9a-7b32ab75f51d</zipfile_location>
+		<zipfile_datetime>20210903_135324</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T13:53:24Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>159292235</number>
+		<title>1W7RH620</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=103ad6c0-bbae-4935-9144-7c078be262a2</zipfile_location>
+		<zipfile_datetime>20240227_063714</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:14Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1157596601</number>
+		<title>1R7YS980</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=9a2aa899-644a-4447-b786-7c0d900aecca</zipfile_location>
+		<zipfile_datetime>20210903_121116</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T12:11:16Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1823823708</number>
+		<title>1H7TI540</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=59c18482-5e01-4a86-b6a3-7c5469754fcf</zipfile_location>
+		<zipfile_datetime>20211012_145501</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-10-12T14:55:01Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3340138154</number>
+		<title>1W7RH190</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=96cbac77-5596-45c9-87d0-7c593b342ba3</zipfile_location>
+		<zipfile_datetime>20201022_171711</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-22T17:17:11Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4259756960</number>
+		<title>1R7LE930</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=4dc318ae-e07b-4195-9e15-7c5ba861f6ab</zipfile_location>
+		<zipfile_datetime>20210903_135817</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T13:58:17Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2181034422</number>
+		<title>1W7MA330</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=24d8fd3e-b6c8-4d02-8b66-7c6023895007</zipfile_location>
+		<zipfile_datetime>20210512_145218</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-12T14:52:18Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2070662410</number>
+		<title>2WBD1892</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=c5bb86ae-bad7-43f0-866f-7c7d5204caae</zipfile_location>
+		<zipfile_datetime>20240830_063633</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-30T06:36:33Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1832231927</number>
+		<title>1W7ML000</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=5ed7c7ef-2a02-41ea-a316-7c95775a7812</zipfile_location>
+		<zipfile_datetime>20210908_095526</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:26Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2262823643</number>
+		<title>1W7NE000</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=6b42b8e6-865b-4632-b9d6-7cd8796335a4</zipfile_location>
+		<zipfile_datetime>20230804_063500</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-08-04T06:35:00Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>154940937</number>
+		<title>2WBD1960</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=7c1de3eb-9e58-4b95-a8e3-7d6fc659dddc</zipfile_location>
+		<zipfile_datetime>20230930_063725</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-09-30T06:37:25Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2311555043</number>
+		<title>2R71016S</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=611d9da1-8fdd-4c91-bccf-7dcaa9235dbd</zipfile_location>
+		<zipfile_datetime>20210126_112612</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-01-26T11:26:12Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1073733018</number>
+		<title>1R7LE936</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=3dfd2d1a-eee3-427b-9a93-7dda72a0a6fd</zipfile_location>
+		<zipfile_datetime>20210903_140058</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T14:00:58Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>481235093</number>
+		<title>2P7D1194</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=faff5d08-161d-4aa0-84e6-7e5aa882548b</zipfile_location>
+		<zipfile_datetime>20230408_063537</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-08T06:35:37Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3216503873</number>
+		<title>4V5005DE</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=b5a1a88b-38d7-47ac-8698-7e85b712252b</zipfile_location>
+		<zipfile_datetime>20201022_171704</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-22T17:17:04Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2793019396</number>
+		<title>9DBEL760</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=df9e2281-40fc-4286-9bac-7ebbbc4ac486</zipfile_location>
+		<zipfile_datetime>20230331_063527</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-03-31T06:35:27Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3266329945</number>
+		<title>1W7WE220</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=db4f3110-215a-4da2-867c-7ee2175ec745</zipfile_location>
+		<zipfile_datetime>20210908_095537</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:37Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3157139726</number>
+		<title>3R7D0211</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=9eae745b-f42a-446b-b0e0-7f161fdc3c81</zipfile_location>
+		<zipfile_datetime>20240613_063559</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-06-13T06:35:59Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>903218392</number>
+		<title>2P7D1044</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=76346c71-41d2-4f5a-8e24-7f59cf561d8e</zipfile_location>
+		<zipfile_datetime>20230408_063535</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-08T06:35:35Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4033207005</number>
+		<title>3R7D0703</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=66224523-2919-4314-bed6-7f6c22d366a8</zipfile_location>
+		<zipfile_datetime>20240821_063618</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-21T06:36:18Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3471509127</number>
+		<title>1W7SKS00</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=6be218d2-7b18-449d-870d-7f823d63e92c</zipfile_location>
+		<zipfile_datetime>20210908_095536</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:36Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>333573240</number>
+		<title>1H7TI270</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=a8ece470-1ad6-4df9-aa6b-7fc7d97b41b7</zipfile_location>
+		<zipfile_datetime>20211012_145454</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-10-12T14:54:54Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>65224986</number>
+		<title>2W7D1910</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=cafc1ae4-c8b4-4639-8641-7ff21484a8ee</zipfile_location>
+		<zipfile_datetime>20230930_063657</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-09-30T06:36:57Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3401889689</number>
+		<title>2WBDHENS</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=56e8b700-648f-49e0-a7be-801c98eb0b8c</zipfile_location>
+		<zipfile_datetime>20240731_063656</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-07-31T06:36:56Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>816580328</number>
+		<title>1W7EL550</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=a36a4920-9416-4485-a685-80551da81c8e</zipfile_location>
+		<zipfile_datetime>20230207_063519</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-02-07T06:35:19Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3026042652</number>
+		<title>1H7TI590</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=2d1ef193-f307-410c-a7f3-805fd5726a62</zipfile_location>
+		<zipfile_datetime>20211012_145504</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-10-12T14:55:04Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>934225194</number>
+		<title>2P7D0966</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=27f3d4ab-7d44-4a3c-9262-808fd48f5a4d</zipfile_location>
+		<zipfile_datetime>20230408_063534</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-08T06:35:34Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3258255963</number>
+		<title>1W7RH690</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=bca9724e-8ed8-4a55-acac-80c5385ff0ec</zipfile_location>
+		<zipfile_datetime>20210503_145644</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-03T14:56:44Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4208865093</number>
+		<title>1W7D2220</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=56f22261-6432-4be0-a5d1-80dd4c6b6ed1</zipfile_location>
+		<zipfile_datetime>20220730_063457</zipfile_datetime>
+		<zipfile_datetime_iso8601>2022-07-30T06:34:57Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1688492856</number>
+		<title>7V7BOHE5</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=b6bed26a-52b5-4815-996c-80dffe6e43be</zipfile_location>
+		<zipfile_datetime>20210701_111256</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:12:56Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2649010077</number>
+		<title>2R70990A</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=ff8b3207-0b59-42d5-a391-80ef98f86459</zipfile_location>
+		<zipfile_datetime>20210126_112611</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-01-26T11:26:11Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>22089628</number>
+		<title>9D7EL740</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=124b5a6b-6489-47c7-8d28-817947c237a1</zipfile_location>
+		<zipfile_datetime>20230331_063526</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-03-31T06:35:26Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2711582183</number>
+		<title>1W7EL170</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=3a52c4d1-8085-48e2-90a1-817ca296ec5f</zipfile_location>
+		<zipfile_datetime>20240227_063718</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:18Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2812499679</number>
+		<title>1H7TI650</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=ee39ae86-5957-4aea-9a2b-81c4a0c162b7</zipfile_location>
+		<zipfile_datetime>20211012_145505</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-10-12T14:55:05Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>897979550</number>
+		<title>2P7D1124</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=99fcb90f-fd87-4c72-86a7-81cbcca76e02</zipfile_location>
+		<zipfile_datetime>20230408_063536</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-08T06:35:36Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3477073969</number>
+		<title>2P7D1294</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=b8c04536-f7f6-4187-a6e6-81d33bf7ab17</zipfile_location>
+		<zipfile_datetime>20230408_063538</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-08T06:35:38Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2580617857</number>
+		<title>7V7BZS05</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=8c4b80d2-4b55-4235-9d7d-822c2b0ab6d4</zipfile_location>
+		<zipfile_datetime>20210701_111122</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:11:22Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4237077608</number>
+		<title>3R7D1064</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=fa84da24-5a36-42f6-ab1b-823af42d8413</zipfile_location>
+		<zipfile_datetime>20201209_103453</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-12-09T10:34:53Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1901927233</number>
+		<title>1W7ML070</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=bdc479ea-109c-433f-ada8-827aa0669a58</zipfile_location>
+		<zipfile_datetime>20210908_095528</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:28Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3056050602</number>
+		<title>1H7D1610</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=2253b84d-03dc-42bc-a15c-8280a4e7fff0</zipfile_location>
+		<zipfile_datetime>20230712_063524</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-07-12T06:35:24Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3915241671</number>
+		<title>2WBD1980</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=c1842233-6b2b-42df-9ad9-82e2bbfa038c</zipfile_location>
+		<zipfile_datetime>20240731_063649</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-07-31T06:36:49Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1891424205</number>
+		<title>1W7MD020</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=5d200a79-9f3d-40c1-a5d3-82f597a8bb53</zipfile_location>
+		<zipfile_datetime>20210512_145219</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-12T14:52:19Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3257076156</number>
+		<title>2WBD2120</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=8b3c0b3f-71cc-408b-815a-8328158b9bb9</zipfile_location>
+		<zipfile_datetime>20230930_063728</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-09-30T06:37:28Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>293483246</number>
+		<title>9H7EL616</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=fbd925c0-3916-4be6-9b63-834565a67776</zipfile_location>
+		<zipfile_datetime>20230804_063501</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-08-04T06:35:01Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1608180977</number>
+		<title>1W7UH130</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=794751d9-66ad-41df-934b-836b9d6a1cab</zipfile_location>
+		<zipfile_datetime>20231011_063504</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-10-11T06:35:04Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1086318517</number>
+		<title>9D7VL000</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=8230476a-021a-4fb8-ae0b-8382d0ba120b</zipfile_location>
+		<zipfile_datetime>20230331_063530</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-03-31T06:35:30Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>473753313</number>
+		<title>3R7DBB05</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=4dfe249f-2962-48fd-856f-83d897a82fec</zipfile_location>
+		<zipfile_datetime>20230214_063449</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-02-14T06:34:49Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2413158675</number>
+		<title>1W7DHK03</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=0aa3c6b6-699f-4575-a27c-8412245e89c5</zipfile_location>
+		<zipfile_datetime>20230413_063523</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-13T06:35:23Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1692855517</number>
+		<title>2W7D2170</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=12fa13c4-896e-4739-9342-848e4535c1f4</zipfile_location>
+		<zipfile_datetime>20240501_063821</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-05-01T06:38:21Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4087341613</number>
+		<title>3R7DCC03</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=6c8d90eb-9507-4058-a388-849dad84d909</zipfile_location>
+		<zipfile_datetime>20220423_095653</zipfile_datetime>
+		<zipfile_datetime_iso8601>2022-04-23T09:56:53Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1442935644</number>
+		<title>9H7EL612</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=cc3bca19-2d67-49c5-8d04-84acfebd1b5e</zipfile_location>
+		<zipfile_datetime>20230804_063500</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-08-04T06:35:00Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3531532262</number>
+		<title>1W7WOD10</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=13ef033e-836a-4eb4-9d1c-84cb12e97567</zipfile_location>
+		<zipfile_datetime>20201016_162828</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-16T16:28:28Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4207502363</number>
+		<title>1W7NE080</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=cbeb32d0-7a2c-4410-9a56-852d51484fee</zipfile_location>
+		<zipfile_datetime>20210914_095426</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-14T09:54:26Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>169499153</number>
+		<title>3R7DBB07</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=c4aa806f-56d8-4b0c-a674-85e7a924d7dd</zipfile_location>
+		<zipfile_datetime>20230214_063449</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-02-14T06:34:49Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3836426536</number>
+		<title>1R7KM000</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=7210f93b-5b32-484a-a763-85fa569cb05c</zipfile_location>
+		<zipfile_datetime>20210903_165105</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T16:51:05Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3229598432</number>
+		<title>1R7MA210</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=e2fc2604-4db6-4cc6-8af7-863955718e53</zipfile_location>
+		<zipfile_datetime>20210903_120122</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T12:01:22Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>746543667</number>
+		<title>3R7D0630</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=f704fbc0-452c-4fac-9db8-8640ee22f588</zipfile_location>
+		<zipfile_datetime>20240821_063616</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-21T06:36:16Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2637583520</number>
+		<title>1R7MA089</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=e6e1e282-fef3-4713-ad0c-865f9ed06dcc</zipfile_location>
+		<zipfile_datetime>20210607_222749</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-06-07T22:27:49Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3201191893</number>
+		<title>1W7MA340</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=1f370d23-0732-4458-93a0-866328a7fce3</zipfile_location>
+		<zipfile_datetime>20210512_145218</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-12T14:52:18Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2696526450</number>
+		<title>1W7MA300</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=b71ed3e6-c584-41d3-abcb-868d726ccc93</zipfile_location>
+		<zipfile_datetime>20210512_145217</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-12T14:52:17Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1826421132</number>
+		<title>2W7D2110</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=03a57b86-aa73-4b34-bef3-86974aec5de8</zipfile_location>
+		<zipfile_datetime>20230930_063708</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-09-30T06:37:08Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2415159796</number>
+		<title>1W7WE350</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=027d1d78-2f84-4767-98cf-87043fdefb0d</zipfile_location>
+		<zipfile_datetime>20210908_095540</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:40Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4247933922</number>
+		<title>1W7ELK40</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=ef32c5fc-c559-414d-b212-872a6344f2ce</zipfile_location>
+		<zipfile_datetime>20210512_145248</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-12T14:52:48Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1444434347</number>
+		<title>3R7D0063</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=05c9bcb2-29f3-4aa8-9633-874a4242beb1</zipfile_location>
+		<zipfile_datetime>20240824_063610</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-24T06:36:10Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>139803996</number>
+		<title>7V7DTS04</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=96565ea2-5001-430e-aa27-874ff7d68948</zipfile_location>
+		<zipfile_datetime>20210701_111259</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:12:59Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2009562018</number>
+		<title>7V7PLDU4</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=8d66f3e9-3854-49d4-8c05-87a40e045ca8</zipfile_location>
+		<zipfile_datetime>20210701_111437</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:14:37Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3728900553</number>
+		<title>1H7SZD01</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=944e010e-760a-46cb-9ecf-87ab34be9ce6</zipfile_location>
+		<zipfile_datetime>20201016_162819</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-16T16:28:19Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3444535309</number>
+		<title>1W7MA030</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=bf6d995f-dffe-4135-9122-87b1398266ad</zipfile_location>
+		<zipfile_datetime>20210512_145209</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-12T14:52:09Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>920483</number>
+		<title>3R7PAM01</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=f950c0b7-fbc3-4f45-b294-87b5fe45cfcb</zipfile_location>
+		<zipfile_datetime>20220423_095653</zipfile_datetime>
+		<zipfile_datetime_iso8601>2022-04-23T09:56:53Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>319632180</number>
+		<title>2R71002S</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=51e6636c-4985-4223-9643-87b636ef3c31</zipfile_location>
+		<zipfile_datetime>20210126_112611</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-01-26T11:26:11Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4204209759</number>
+		<title>3R7D1018</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=5160351e-b3d8-4500-82a8-87cd913ac8a1</zipfile_location>
+		<zipfile_datetime>20201209_103453</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-12-09T10:34:53Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>958182420</number>
+		<title>1W7MA310</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=e711a7df-9759-4d84-8c06-87e72b10db07</zipfile_location>
+		<zipfile_datetime>20210512_145218</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-12T14:52:18Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3318574846</number>
+		<title>2WBD1970</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=2f65d39d-dc5c-4e50-a3cb-8884771c91fc</zipfile_location>
+		<zipfile_datetime>20230930_063725</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-09-30T06:37:25Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3681541794</number>
+		<title>1W7D2320</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=501805ee-1abc-49f8-9762-8889885aab24</zipfile_location>
+		<zipfile_datetime>20220611_063523</zipfile_datetime>
+		<zipfile_datetime_iso8601>2022-06-11T06:35:23Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>798941824</number>
+		<title>1R7ZE029</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=b4d8b274-0ae0-49cb-a240-88b6fa198c27</zipfile_location>
+		<zipfile_datetime>20210903_132918</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T13:29:18Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3855863538</number>
+		<title>1W7SO010</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=5afea150-68df-427e-aa4b-88dbce05015c</zipfile_location>
+		<zipfile_datetime>20221103_063448</zipfile_datetime>
+		<zipfile_datetime_iso8601>2022-11-03T06:34:48Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>477337266</number>
+		<title>1W7DHK00</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=0cd5ed33-f5ed-412a-9fa8-88df1ef8168c</zipfile_location>
+		<zipfile_datetime>20210503_145608</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-03T14:56:08Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3193975645</number>
+		<title>9D7EL829</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=22946c04-ed9b-4097-943c-8922ca824c2b</zipfile_location>
+		<zipfile_datetime>20230331_063529</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-03-31T06:35:29Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3531793732</number>
+		<title>1W7RH570</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=25fa6170-3706-44ea-aaa8-893b45c9ed00</zipfile_location>
+		<zipfile_datetime>20240227_063712</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:12Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2308104054</number>
+		<title>7V7DEKW1</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=5242b66d-a1f6-4b21-adc5-895513fb05fb</zipfile_location>
+		<zipfile_datetime>20210701_111257</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:12:57Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1017634777</number>
+		<title>1H7TI180</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=a6c7a915-8161-4659-bf8b-8962f4662d9d</zipfile_location>
+		<zipfile_datetime>20211012_145450</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-10-12T14:54:50Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3648504704</number>
+		<title>3R7D0047</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=146709ba-4b28-4156-9951-899ef7eeb6cd</zipfile_location>
+		<zipfile_datetime>20240824_063610</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-24T06:36:10Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1729217105</number>
+		<title>1R7YM009</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=a986bbce-d382-4bc0-8396-89cc9de5cd0b</zipfile_location>
+		<zipfile_datetime>20210903_123959</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T12:39:59Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4223251201</number>
+		<title>1H7D1776</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=fbe10e21-82ae-42a9-b83c-8a8b39f54260</zipfile_location>
+		<zipfile_datetime>20230712_063527</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-07-12T06:35:27Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1526013622</number>
+		<title>3B7D0515</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=f31c674e-eaa1-464d-9938-8b3ad4373ad0</zipfile_location>
+		<zipfile_datetime>20240829_063724</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-29T06:37:24Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2017101305</number>
+		<title>1R7ZE005</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=bdc6865d-6a13-4fed-8d60-8b44ec60a88d</zipfile_location>
+		<zipfile_datetime>20210903_132607</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T13:26:07Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3507465776</number>
+		<title>3R7D0304</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=41d91159-dac4-4404-aa53-8b8175777846</zipfile_location>
+		<zipfile_datetime>20230919_063546</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-09-19T06:35:46Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1178103770</number>
+		<title>1W7MA150</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=b5a42a53-1ff5-4900-8898-8b8b393b6123</zipfile_location>
+		<zipfile_datetime>20210512_145215</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-12T14:52:15Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1992011276</number>
+		<title>1W7OD560</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=7a8367af-f748-44a5-a39c-8bb7503a29b7</zipfile_location>
+		<zipfile_datetime>20210205_120407</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-02-05T12:04:07Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>685991511</number>
+		<title>4V5006DE</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=be7deed7-0ca6-4c43-b1d3-8c02602bd1c7</zipfile_location>
+		<zipfile_datetime>20201022_171704</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-22T17:17:04Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>60267146</number>
+		<title>1W7RH650</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=cc6fcda7-eab0-4488-b2d2-8c42692c56b3</zipfile_location>
+		<zipfile_datetime>20210503_145643</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-03T14:56:43Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3281104856</number>
+		<title>1H7D1490</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=d5aa2847-331a-4640-8f67-8cae622db38e</zipfile_location>
+		<zipfile_datetime>20230712_063522</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-07-12T06:35:22Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3339817320</number>
+		<title>7V7ALB10</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=c2f50edf-3978-4969-85ab-8cb44d2c9763</zipfile_location>
+		<zipfile_datetime>20210701_110743</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:07:43Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3295362577</number>
+		<title>4V5RHO00</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=d74ea086-815f-457d-b118-8cc00f27b52e</zipfile_location>
+		<zipfile_datetime>20201022_171712</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-22T17:17:12Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3136815349</number>
+		<title>2P7SA023</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=1a76f8b9-96e2-40e1-a8fd-8cd93af9f85a</zipfile_location>
+		<zipfile_datetime>20230413_063521</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-13T06:35:21Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3498670771</number>
+		<title>1W7EL080</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=4150d73d-b213-4e33-a465-8d1f8bae93d4</zipfile_location>
+		<zipfile_datetime>20240227_063716</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:16Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1349034972</number>
+		<title>1W7EL140</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=51ab4af5-420d-46bf-9382-8d4d7ead0980</zipfile_location>
+		<zipfile_datetime>20240227_063717</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:17Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3334459338</number>
+		<title>2WBD1913</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=fae62493-852a-4e21-afa5-8d7188b30e70</zipfile_location>
+		<zipfile_datetime>20240614_063725</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-06-14T06:37:25Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3241736960</number>
+		<title>1W7EL450</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=cdf2ed22-d59c-4fb6-bf7e-8dbd0dc34bb0</zipfile_location>
+		<zipfile_datetime>20240227_063723</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:23Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1705148569</number>
+		<title>1W7RH480</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=fee935fb-dfcd-43c5-95bb-8e4aaf41ca50</zipfile_location>
+		<zipfile_datetime>20240227_063711</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:11Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>636883316</number>
+		<title>2WBD2012</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=a5e20fe8-b63c-408e-abd7-8e6522bf2991</zipfile_location>
+		<zipfile_datetime>20240830_063633</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-30T06:36:33Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>973862820</number>
+		<title>1R7NK000</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=a2f07026-032d-4c59-ad13-8e68c1b7011b</zipfile_location>
+		<zipfile_datetime>20210903_150210</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T15:02:10Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2960838012</number>
+		<title>1W7EL540</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=a7b7771d-28de-44dd-b6b7-8e7685d15029</zipfile_location>
+		<zipfile_datetime>20230207_063519</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-02-07T06:35:19Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2356947380</number>
+		<title>1W7MO190</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=55e359ea-9b59-4d81-9925-8eb63721e113</zipfile_location>
+		<zipfile_datetime>20210908_095522</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:22Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>822840640</number>
+		<title>1H7TI340</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=96ead57f-2026-4dd8-8699-8f21f4952e40</zipfile_location>
+		<zipfile_datetime>20211012_145456</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-10-12T14:54:56Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2499693222</number>
+		<title>1W7KK004</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=3e576f56-dfe6-4191-bce6-8fac08296f26</zipfile_location>
+		<zipfile_datetime>20210503_145616</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-03T14:56:16Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1928171525</number>
+		<title>2WBD2092</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=88bc469b-0895-4c7b-ad13-8fb6a5c1f1a7</zipfile_location>
+		<zipfile_datetime>20240529_063638</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-05-29T06:36:38Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3549675923</number>
+		<title>7V7ZWV01</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=0aa55d72-fcb7-44c2-a708-8fdb77b7207e</zipfile_location>
+		<zipfile_datetime>20210701_105057</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T10:50:57Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1987142635</number>
+		<title>2WBD2013</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=c6af4b3a-a0a6-4985-8ef5-8ff57ae3caf4</zipfile_location>
+		<zipfile_datetime>20240731_063652</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-07-31T06:36:52Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>810357122</number>
+		<title>2R71037N</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=31c6a9f6-e071-45a2-b27d-900957b85055</zipfile_location>
+		<zipfile_datetime>20210126_112613</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-01-26T11:26:13Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1895679865</number>
+		<title>2WBD2080</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=8d7e273c-2c90-48c7-b90c-90358c803ca2</zipfile_location>
+		<zipfile_datetime>20230929_063650</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-09-29T06:36:50Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3119136259</number>
+		<title>2R71011N</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=70d70777-d1ad-4bc3-b160-9065f43e078d</zipfile_location>
+		<zipfile_datetime>20210126_112612</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-01-26T11:26:12Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1983560059</number>
+		<title>9D7EL860</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=964ae9f8-8cf9-4dac-bd7c-90bb5ed17f7f</zipfile_location>
+		<zipfile_datetime>20230331_063529</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-03-31T06:35:29Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>111096086</number>
+		<title>1W7EL400</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=cd8d3963-fda5-4909-8ed9-90c1505a5a64</zipfile_location>
+		<zipfile_datetime>20240227_063722</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:22Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>545135532</number>
+		<title>1W7WE330</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=50645dbb-2210-412a-a029-9116124caf20</zipfile_location>
+		<zipfile_datetime>20210908_095540</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:40Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>360303126</number>
+		<title>4V7SEI05</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=ac5ec3ca-8413-453d-8c00-9148d5990a31</zipfile_location>
+		<zipfile_datetime>20240409_164148</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-04-09T16:41:48Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>189244493</number>
+		<title>3R7D0297</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=2d4afaa0-8bec-4a6f-ba0d-91b01c0e762c</zipfile_location>
+		<zipfile_datetime>20230919_063546</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-09-19T06:35:46Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3247954255</number>
+		<title>1R7YM012</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=43d3d98c-d12f-47f2-a0c2-9234413b0fd4</zipfile_location>
+		<zipfile_datetime>20210903_124241</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T12:42:41Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1630985962</number>
+		<title>2WBD1871</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=256bea17-4952-4b68-b587-927d5b9ddd13</zipfile_location>
+		<zipfile_datetime>20240614_063708</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-06-14T06:37:08Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>544298676</number>
+		<title>1W7EL070</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=e551b688-e574-45cb-8d00-92a8940b9657</zipfile_location>
+		<zipfile_datetime>20240227_063716</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:16Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3821403681</number>
+		<title>1H7D1690</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=a5660552-643c-484a-98cb-92e378648a01</zipfile_location>
+		<zipfile_datetime>20230712_063526</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-07-12T06:35:26Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3542001021</number>
+		<title>1W7EL090</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=b861b03e-9415-40de-86ae-933857c6faba</zipfile_location>
+		<zipfile_datetime>20240227_063716</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:16Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2789724068</number>
+		<title>9D7VL087</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=578bae0c-3f2b-409f-b673-9339ba684b44</zipfile_location>
+		<zipfile_datetime>20230331_063531</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-03-31T06:35:31Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3654073285</number>
+		<title>2WBD2001</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=24911bf6-7e0e-4449-a232-93798697ecc9</zipfile_location>
+		<zipfile_datetime>20240731_063650</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-07-31T06:36:50Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2184103819</number>
+		<title>4V5SAO05</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=a9644c86-7cba-43d5-945d-9383c80ad23e</zipfile_location>
+		<zipfile_datetime>20201022_171712</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-22T17:17:12Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2822694081</number>
+		<title>1R7MK050</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=6d6cf7d5-649c-4e50-a697-93bae959ef8d</zipfile_location>
+		<zipfile_datetime>20210903_151025</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T15:10:25Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>283547131</number>
+		<title>1H7TI280</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=787e993d-20e7-47d8-be33-93deec2a0bb8</zipfile_location>
+		<zipfile_datetime>20211012_145454</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-10-12T14:54:54Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>548980958</number>
+		<title>1W7D2360</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=0663aa76-8d18-4adb-8381-93fcc7b87a54</zipfile_location>
+		<zipfile_datetime>20220611_063524</zipfile_datetime>
+		<zipfile_datetime_iso8601>2022-06-11T06:35:24Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>281810289</number>
+		<title>1R7YM007</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=bbe7ee25-032a-42a2-8d9a-940874ac7bbc</zipfile_location>
+		<zipfile_datetime>20210903_123814</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T12:38:14Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2331707433</number>
+		<title>4V5SAO08</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=9e4e7826-baa2-4fe5-ad20-942929b599b6</zipfile_location>
+		<zipfile_datetime>20201022_171712</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-22T17:17:12Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2173012530</number>
+		<title>5C7D1349</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=772ab77f-c147-4df2-83f4-942cdf7c357f</zipfile_location>
+		<zipfile_datetime>20231109_101954</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-11-09T10:19:54Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3845896259</number>
+		<title>1W7ML170</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=92376cff-e25d-4091-b10a-942d30cf3d3b</zipfile_location>
+		<zipfile_datetime>20210908_095530</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:30Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2034878268</number>
+		<title>1H7TI620</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=3cde7f24-0894-43e7-9d78-94823c83ee48</zipfile_location>
+		<zipfile_datetime>20211012_145504</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-10-12T14:55:04Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1615852592</number>
+		<title>1R7WV099</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=1de48b26-0aec-49ef-b831-94b91b619ba2</zipfile_location>
+		<zipfile_datetime>20210903_143341</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T14:33:41Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>569029886</number>
+		<title>2WBD1881</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=b718020c-f543-4405-a594-94f4a3f6442b</zipfile_location>
+		<zipfile_datetime>20240614_063712</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-06-14T06:37:12Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2911542000</number>
+		<title>1W7WE260</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=33a3c5e4-e17b-49ce-bf8e-94f6df3bdb20</zipfile_location>
+		<zipfile_datetime>20210908_095538</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:38Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>285290158</number>
+		<title>3R7BM009</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=b4b37a05-e2c4-4bac-838e-954b44c3214f</zipfile_location>
+		<zipfile_datetime>20220326_095422</zipfile_datetime>
+		<zipfile_datetime_iso8601>2022-03-26T09:54:22Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3409214469</number>
+		<title>1H7TI360</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=022cc7bf-f7f8-4b9f-a7a1-9593253ec249</zipfile_location>
+		<zipfile_datetime>20211012_145456</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-10-12T14:54:56Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3685202659</number>
+		<title>1W7ML210</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=a1b702d8-3057-4100-b6c2-9594c5b75986</zipfile_location>
+		<zipfile_datetime>20210908_095531</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:31Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3711872889</number>
+		<title>4V7OIS05</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=eeac5e06-a057-4500-9a89-9595c562239f</zipfile_location>
+		<zipfile_datetime>20240409_171442</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-04-09T17:14:42Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3555950491</number>
+		<title>1R7AR022</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=f5eb59c0-4e92-44a2-9494-95e0ba7b1081</zipfile_location>
+		<zipfile_datetime>20210313_184258</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-03-13T18:42:58Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>129242525</number>
+		<title>1W7D2200</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=4a5475ff-c735-4736-b850-95f765f9757f</zipfile_location>
+		<zipfile_datetime>20220730_063457</zipfile_datetime>
+		<zipfile_datetime_iso8601>2022-07-30T06:34:57Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4197535556</number>
+		<title>3R7DCC04</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=129cad1f-a80c-4ea8-b1a0-95f7d8e9855e</zipfile_location>
+		<zipfile_datetime>20220423_095653</zipfile_datetime>
+		<zipfile_datetime_iso8601>2022-04-23T09:56:53Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4189323437</number>
+		<title>1W7EL570</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=5e28cfde-e08b-4b18-b0c3-96091ee96bb3</zipfile_location>
+		<zipfile_datetime>20230207_063519</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-02-07T06:35:19Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1485266374</number>
+		<title>4V6GA070</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=3529a775-a21e-41d3-b44c-960f67d5f957</zipfile_location>
+		<zipfile_datetime>20201022_171708</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-22T17:17:08Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2515697290</number>
+		<title>3R7SFG03</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=a7b8dc0e-6605-45f7-9c0e-96ad76113f0f</zipfile_location>
+		<zipfile_datetime>20201016_162825</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-16T16:28:25Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2977438673</number>
+		<title>3R7D0846</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=a6223013-d9c2-4833-a71b-96b28e51603c</zipfile_location>
+		<zipfile_datetime>20201209_103450</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-12-09T10:34:50Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>471727462</number>
+		<title>1W7SO030</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=9f2d7570-4bbe-43a2-8ab6-96ea3662f628</zipfile_location>
+		<zipfile_datetime>20240227_063725</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:25Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>322881177</number>
+		<title>1W7ML280</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=4150b946-6216-4752-90e8-97825eef5c72</zipfile_location>
+		<zipfile_datetime>20210908_095535</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:35Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3088125494</number>
+		<title>7V7KRLEI</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=3952ebc4-8d9b-484a-87ac-97a49c23e71c</zipfile_location>
+		<zipfile_datetime>20210701_112112</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:21:12Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2119298380</number>
+		<title>2WBD1990</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=ec356d81-4d5e-421f-92dc-97ec259c02ff</zipfile_location>
+		<zipfile_datetime>20240731_063649</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-07-31T06:36:49Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2679522881</number>
+		<title>1W7MD110</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=9c8677dc-84b0-4f8e-8928-97fb77aee96a</zipfile_location>
+		<zipfile_datetime>20210512_145224</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-12T14:52:24Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3656321180</number>
+		<title>1R7YS918</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=d2dfdd69-8bc9-4da8-af00-98152ff150f5</zipfile_location>
+		<zipfile_datetime>20210903_121914</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T12:19:14Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1665906288</number>
+		<title>2D7D1864</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=34e2c176-fdfe-4e0f-9196-98398e74abbf</zipfile_location>
+		<zipfile_datetime>20210908_095511</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:11Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1123615315</number>
+		<title>9D7EL726</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=a7c6b94e-2b40-452c-b29f-987a6f2390d1</zipfile_location>
+		<zipfile_datetime>20230331_063525</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-03-31T06:35:25Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1550402582</number>
+		<title>2P7D1378</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=3625332c-ba06-4087-b279-98b6f3c73c4c</zipfile_location>
+		<zipfile_datetime>20230408_063539</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-08T06:35:39Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>207331305</number>
+		<title>9D7EL880</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=f74bfaa0-5ab8-4b37-8ae2-98bd550895f6</zipfile_location>
+		<zipfile_datetime>20230331_063529</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-03-31T06:35:29Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2130499644</number>
+		<title>1W7EL210</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=bada3a26-dfd9-4629-87c9-98f937c4c03f</zipfile_location>
+		<zipfile_datetime>20240227_063719</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:19Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1082249550</number>
+		<title>9DBEL750</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=06146ef7-a4aa-4aa1-ac08-994a6660ecec</zipfile_location>
+		<zipfile_datetime>20230331_063527</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-03-31T06:35:27Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4291805884</number>
+		<title>4V7SEI01</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=8511533e-75a9-4318-92f2-99931944ff3e</zipfile_location>
+		<zipfile_datetime>20240409_164222</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-04-09T16:42:22Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>814021453</number>
+		<title>3R7DBB04</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=dae37493-4f07-4179-9dcc-9a1244323b41</zipfile_location>
+		<zipfile_datetime>20230214_063448</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-02-14T06:34:48Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>698516921</number>
+		<title>9D7VL037</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=44051b55-6cc7-4869-a529-9a1c5e1ce1a4</zipfile_location>
+		<zipfile_datetime>20230331_063531</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-03-31T06:35:31Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3495229676</number>
+		<title>1W7ML080</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=c33f5cd6-717a-4168-8669-9ac94f2d6a3d</zipfile_location>
+		<zipfile_datetime>20210908_095528</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:28Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1361352557</number>
+		<title>4V5SAO12</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=cff54405-52ea-4da5-9e45-9be499f2ef82</zipfile_location>
+		<zipfile_datetime>20201022_171713</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-22T17:17:13Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>870135383</number>
+		<title>3B7D0471</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=bc014347-7f70-4bf2-9f2f-9c201be9d745</zipfile_location>
+		<zipfile_datetime>20240829_063723</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-29T06:37:23Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3623026146</number>
+		<title>4V5MOS02</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=4d6c92a4-fdb2-410d-8ce7-9c265ada7304</zipfile_location>
+		<zipfile_datetime>20221201_181711</zipfile_datetime>
+		<zipfile_datetime_iso8601>2022-12-01T18:17:11Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3480666561</number>
+		<title>1W7D2280</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=450dce67-aa49-4192-8337-9c73ea33c542</zipfile_location>
+		<zipfile_datetime>20220611_063523</zipfile_datetime>
+		<zipfile_datetime_iso8601>2022-06-11T06:35:23Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2552573042</number>
+		<title>1W7MO230</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=078a401e-d18f-4e75-9ca7-9ca6bf38b69f</zipfile_location>
+		<zipfile_datetime>20210908_095523</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:23Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3243771776</number>
+		<title>1R7MA165</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=59c6438d-6648-4e36-8dfd-9ca992dd002b</zipfile_location>
+		<zipfile_datetime>20210903_112838</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T11:28:38Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2892635521</number>
+		<title>1W7RH160</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=81617fd1-c59f-4cd8-b1b0-9ce2bce69676</zipfile_location>
+		<zipfile_datetime>20201022_171711</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-22T17:17:11Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1733273778</number>
+		<title>7V7BOSC4</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=a159e3bf-c756-4966-9ab0-9d003d5801da</zipfile_location>
+		<zipfile_datetime>20210701_111120</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:11:20Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4160514542</number>
+		<title>3R7D0004</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=d21dbb7c-28fe-40e7-9be7-9d0498983db8</zipfile_location>
+		<zipfile_datetime>20240613_063601</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-06-13T06:36:01Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3260941704</number>
+		<title>2P7D0887</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=89d62084-4de7-4a58-91db-9d0bcc4e6313</zipfile_location>
+		<zipfile_datetime>20230408_063534</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-08T06:35:34Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2327259264</number>
+		<title>9DBEL755</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=373cb8ee-f1d9-45c1-8ce0-9d1d2b6968a8</zipfile_location>
+		<zipfile_datetime>20230331_063527</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-03-31T06:35:27Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3858134744</number>
+		<title>BE7EV003</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=852057b8-d7d6-475a-bca2-9d769366b208</zipfile_location>
+		<zipfile_datetime>20240820_113028</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-20T11:30:28Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1632564018</number>
+		<title>2WBDHTRN</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=ed608c63-a422-4423-bb34-9da143943ae7</zipfile_location>
+		<zipfile_datetime>20240830_063637</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-30T06:36:37Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1100017768</number>
+		<title>7V7YZER4</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=306faa78-f8aa-4b59-925c-9e31a67ad81f</zipfile_location>
+		<zipfile_datetime>20210701_111303</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:13:03Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>393692426</number>
+		<title>1W7MA110</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=9d728b0a-39de-4c72-b762-9eaa4a6ea062</zipfile_location>
+		<zipfile_datetime>20210512_145214</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-12T14:52:14Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1682198063</number>
+		<title>1W7OD600</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=248aa720-da13-4157-b37b-9ef42cb74cbf</zipfile_location>
+		<zipfile_datetime>20211016_095510</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-10-16T09:55:10Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>629607152</number>
+		<title>1W7EL470</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=ba85effb-8f97-4d2e-a733-9f0570977344</zipfile_location>
+		<zipfile_datetime>20240227_063723</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:23Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>894104542</number>
+		<title>4V5015DE</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=a8de5a49-5c83-49ae-90aa-9f8a85baa3df</zipfile_location>
+		<zipfile_datetime>20201022_171705</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-22T17:17:05Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3803712836</number>
+		<title>3B7D0476</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=130f57f5-a892-4d49-8e00-9ff3f167a585</zipfile_location>
+		<zipfile_datetime>20240829_063723</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-29T06:37:23Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1514158141</number>
+		<title>1H7TI460</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=4c8748d0-0848-4980-b1e3-a0191034c583</zipfile_location>
+		<zipfile_datetime>20211012_145459</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-10-12T14:54:59Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2674229631</number>
+		<title>1W7MA240</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=96dbf2c5-2244-4705-9da3-a088ce24d95e</zipfile_location>
+		<zipfile_datetime>20210512_145216</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-12T14:52:16Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1346668640</number>
+		<title>1W7RH450</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=d18fe327-ad63-474f-a181-a0966c4061f4</zipfile_location>
+		<zipfile_datetime>20240227_063710</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:10Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1588198368</number>
+		<title>1W7DE008</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=98028cd1-226c-42ca-8fdc-a09d868d585a</zipfile_location>
+		<zipfile_datetime>20230413_063524</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-13T06:35:24Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>156927737</number>
+		<title>9D7VL057</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=50cc5f83-5b48-4e0f-8131-a103edc3a8cc</zipfile_location>
+		<zipfile_datetime>20230331_063531</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-03-31T06:35:31Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>449499995</number>
+		<title>1W7KK006</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=0dd27725-a19a-4253-8a11-a17759233762</zipfile_location>
+		<zipfile_datetime>20210503_145617</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-03T14:56:17Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3899346826</number>
+		<title>1R75K7RI</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=d23ea44b-b539-4b55-b252-a17be9c8e748</zipfile_location>
+		<zipfile_datetime>20211009_085150</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-10-09T08:51:50Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>631917820</number>
+		<title>1W7OD620</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=aaa94148-91f6-458d-83ca-a1ad3852dad1</zipfile_location>
+		<zipfile_datetime>20210205_120410</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-02-05T12:04:10Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4167842844</number>
+		<title>1H7TI600</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=8790fd9a-b8b9-4b2a-ac5a-a206b090e38f</zipfile_location>
+		<zipfile_datetime>20211012_145504</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-10-12T14:55:04Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4208131937</number>
+		<title>1R7YS969</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=eaeb34f8-671f-417f-b101-a21421a858e9</zipfile_location>
+		<zipfile_datetime>20210903_121407</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T12:14:07Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3903914581</number>
+		<title>2P7SA010</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=ad5aafc1-4ecb-4f7c-823e-a29992516ba9</zipfile_location>
+		<zipfile_datetime>20230413_063521</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-13T06:35:21Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2574242272</number>
+		<title>4V5004DE</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=57666ee6-36d1-44a3-ad06-a29f9012f239</zipfile_location>
+		<zipfile_datetime>20201022_171704</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-22T17:17:04Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2541339426</number>
+		<title>7V7KLEDI</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=42ab9fc6-379b-4f14-9a42-a2c7dc0470f6</zipfile_location>
+		<zipfile_datetime>20210701_111434</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:14:34Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>295502989</number>
+		<title>3B7D0388</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=868e9cf2-e8ed-43b0-a1ef-a2d98e395014</zipfile_location>
+		<zipfile_datetime>20240829_063721</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-29T06:37:21Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1275894672</number>
+		<title>1W7DE014</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=66fbd0d9-7b14-4e4b-b40b-a2fcfd7a45e9</zipfile_location>
+		<zipfile_datetime>20230413_063524</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-13T06:35:24Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2243990829</number>
+		<title>1W7RH320</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=1b4167e4-1ead-4230-bb59-a3fe92e83202</zipfile_location>
+		<zipfile_datetime>20240227_063708</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:08Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1949798202</number>
+		<title>1W7MA380</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=eed23304-d55c-4385-8eeb-a44aff0efba9</zipfile_location>
+		<zipfile_datetime>20210512_145219</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-12T14:52:19Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3203003177</number>
+		<title>1H7D1520</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=cd2d372e-a9c6-4a00-bda1-a45d4649ff87</zipfile_location>
+		<zipfile_datetime>20230712_063522</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-07-12T06:35:22Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3466971347</number>
+		<title>1W7SL085</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=d1f74ab7-8187-49e4-b2c8-a477ab857df0</zipfile_location>
+		<zipfile_datetime>20231011_063506</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-10-11T06:35:06Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3952745835</number>
+		<title>1R7HV002</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=bc47e780-ad63-4d5c-855f-a4937856bdc7</zipfile_location>
+		<zipfile_datetime>20210903_134512</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T13:45:12Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>699018700</number>
+		<title>9D7EL820</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=78f5641a-e4f4-4258-bc5e-a49ec890a1ef</zipfile_location>
+		<zipfile_datetime>20230331_063528</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-03-31T06:35:28Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2093107200</number>
+		<title>1H7TI160</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=0048e039-646d-4029-b377-a4b57ef46496</zipfile_location>
+		<zipfile_datetime>20211012_145450</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-10-12T14:54:50Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2544259</number>
+		<title>1W7DE012</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=f08f7075-9960-46be-9e0d-a50880abfccb</zipfile_location>
+		<zipfile_datetime>20240227_063706</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:06Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2231206834</number>
+		<title>1W7OD670</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=2af53952-ff3d-4c63-b1ac-a52dd686d220</zipfile_location>
+		<zipfile_datetime>20210205_120411</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-02-05T12:04:11Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2685194599</number>
+		<title>1W7MD160</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=82311f7d-2c72-4c10-b733-a5c6e77bd147</zipfile_location>
+		<zipfile_datetime>20210512_145225</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-12T14:52:25Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>187323513</number>
+		<title>3R7D0078</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=63307b04-0728-4341-a687-a60308992d4d</zipfile_location>
+		<zipfile_datetime>20240824_063611</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-24T06:36:11Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>659956986</number>
+		<title>9DBEL745</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=755a3621-fa44-41c8-8ea8-a6508e9be502</zipfile_location>
+		<zipfile_datetime>20230331_063527</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-03-31T06:35:27Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3002374025</number>
+		<title>4V5008DE</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=0c8cf53e-3901-4976-8e69-a69aa26cec51</zipfile_location>
+		<zipfile_datetime>20201022_171704</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-22T17:17:04Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>223498477</number>
+		<title>2W7D1880</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=60ea6945-606e-401b-b6e6-a6ccdbcca788</zipfile_location>
+		<zipfile_datetime>20240529_063629</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-05-29T06:36:29Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2504717291</number>
+		<title>2WBD2110</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=ea9a5da1-1436-41f5-aca4-a6edd743d431</zipfile_location>
+		<zipfile_datetime>20240529_063639</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-05-29T06:36:39Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3449743494</number>
+		<title>2W7D1870</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=6b155f34-75d0-488a-902e-a722395e182d</zipfile_location>
+		<zipfile_datetime>20240628_063618</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-06-28T06:36:18Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>439622579</number>
+		<title>1W7HO060</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=9d8d93e7-8b10-48c9-b347-a77d26efa5eb</zipfile_location>
+		<zipfile_datetime>20201016_162828</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-16T16:28:28Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3406232071</number>
+		<title>1R7MA103</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=c5b4e141-91b1-4335-afa6-a78f38ef2af3</zipfile_location>
+		<zipfile_datetime>20210607_222925</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-06-07T22:29:25Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2099629654</number>
+		<title>3R7D0742</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=eb6459d6-9079-4eb3-a29d-a7a9363d4d8f</zipfile_location>
+		<zipfile_datetime>20240821_063620</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-21T06:36:20Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>602144466</number>
+		<title>1W7EL060</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=437cfd9c-9c5b-48b2-9125-a7be2e06b3ee</zipfile_location>
+		<zipfile_datetime>20240227_063716</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:16Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>786434939</number>
+		<title>4V5009DE</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=f96ac0fe-f742-43ad-a786-a80e333c042e</zipfile_location>
+		<zipfile_datetime>20201022_171704</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-22T17:17:04Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1050087764</number>
+		<title>3RB4DCC1</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=96d41988-fff8-474e-af2a-a84133be49f4</zipfile_location>
+		<zipfile_datetime>20230919_063548</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-09-19T06:35:48Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1246895804</number>
+		<title>1W7PHV10</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=aa25d5f5-2b05-4c4a-b2ab-a9078c0403da</zipfile_location>
+		<zipfile_datetime>20231011_063507</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-10-11T06:35:07Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3764152785</number>
+		<title>1H7D1630</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=43b53bfd-7130-45ad-ac31-a9b1be926627</zipfile_location>
+		<zipfile_datetime>20230712_063524</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-07-12T06:35:24Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3479375296</number>
+		<title>1R7YM016</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=3524095b-97bc-4007-ad62-a9c340a54ba0</zipfile_location>
+		<zipfile_datetime>20210903_124622</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T12:46:22Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2922282251</number>
+		<title>2R71002N</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=f20792a1-e90a-432d-96c7-a9c9b9af5d70</zipfile_location>
+		<zipfile_datetime>20210126_112611</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-01-26T11:26:11Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>190088442</number>
+		<title>3B7D0531</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=0a5adc2f-f37b-44c1-bcb4-a9d3a9d48024</zipfile_location>
+		<zipfile_datetime>20240829_063724</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-29T06:37:24Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1783392775</number>
+		<title>2WBD1915</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=10449d43-c62a-45a7-9078-aa045ee9982e</zipfile_location>
+		<zipfile_datetime>20240614_063726</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-06-14T06:37:26Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2658942652</number>
+		<title>1W7SO070</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=1b7e01fc-b02e-4138-9363-aa0e2998b5d6</zipfile_location>
+		<zipfile_datetime>20231011_063508</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-10-11T06:35:08Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>741794705</number>
+		<title>1W7ML160</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=c5680745-067a-4602-b2f5-aa1585ef103f</zipfile_location>
+		<zipfile_datetime>20210908_095530</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:30Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2527038657</number>
+		<title>7V7DTS03</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=446edfdd-0437-4390-ad73-aa54c5fd7749</zipfile_location>
+		<zipfile_datetime>20210701_111258</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:12:58Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>310509106</number>
+		<title>1H7TI290</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=99a9aef1-7681-4f73-804d-aa926767c625</zipfile_location>
+		<zipfile_datetime>20211012_145455</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-10-12T14:54:55Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2543333084</number>
+		<title>7V7GENO4</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=850a6560-8083-4023-8318-aab8bc7672a7</zipfile_location>
+		<zipfile_datetime>20210701_111432</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:14:32Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>499626135</number>
+		<title>2P7SA048</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=472d6eaf-5ca7-4f02-9261-aacfb7f83334</zipfile_location>
+		<zipfile_datetime>20230413_063521</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-13T06:35:21Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2287544403</number>
+		<title>7V7IEPER</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=8acac27b-2b73-4b9e-bc6c-aafff9da007e</zipfile_location>
+		<zipfile_datetime>20210701_111433</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:14:33Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1384997952</number>
+		<title>1W7SR040</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=22a3f2fb-2a05-44d1-98f4-abb7b90e28d8</zipfile_location>
+		<zipfile_datetime>20210908_095525</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:25Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3557849255</number>
+		<title>1W7D2340</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=0085afc6-41cd-42cf-92cf-abd0d9cb20f7</zipfile_location>
+		<zipfile_datetime>20220611_063524</zipfile_datetime>
+		<zipfile_datetime_iso8601>2022-06-11T06:35:24Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2499123776</number>
+		<title>5C7D1321</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=4a07670b-deb9-437c-ab14-abd197adabf3</zipfile_location>
+		<zipfile_datetime>20231109_105317</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-11-09T10:53:17Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>123868063</number>
+		<title>5C7D1334</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=f7a111a5-3605-42a6-9e6f-ac00e07b23a5</zipfile_location>
+		<zipfile_datetime>20231109_101843</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-11-09T10:18:43Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3542043275</number>
+		<title>4V5014DE</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=811b5a18-bf4d-4bcb-834f-ac1ef127f152</zipfile_location>
+		<zipfile_datetime>20201022_171705</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-22T17:17:05Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1250165833</number>
+		<title>7V7BOHE2</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=4b13afd1-0278-4558-a216-ac2406237e2b</zipfile_location>
+		<zipfile_datetime>20210701_111254</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:12:54Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1024773759</number>
+		<title>1W7ML190</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=09214286-af2f-4623-a17e-ac34ac2b0e75</zipfile_location>
+		<zipfile_datetime>20210908_095531</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:31Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3815931848</number>
+		<title>1W7NE050</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=89f5a159-cc38-4059-bc5f-ac3e680ba6e3</zipfile_location>
+		<zipfile_datetime>20210914_095422</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-14T09:54:22Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>691307034</number>
+		<title>2P7D1027</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=ecedd708-d571-472c-be3c-ac42c3d87e14</zipfile_location>
+		<zipfile_datetime>20230408_063535</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-08T06:35:35Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2145867971</number>
+		<title>1W7MD050</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=79e567e9-975c-4195-a374-accfacc9ed13</zipfile_location>
+		<zipfile_datetime>20210512_145220</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-12T14:52:20Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>927178712</number>
+		<title>1W7DE013</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=2f84b95d-1f2b-4c69-86da-acf7c0ae00ea</zipfile_location>
+		<zipfile_datetime>20210908_095513</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:13Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2908263024</number>
+		<title>1W7HO097</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=4644f439-b418-4f0e-bffa-ad266bda3cf5</zipfile_location>
+		<zipfile_datetime>20210205_120405</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-02-05T12:04:05Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2311743611</number>
+		<title>3R7PAM03</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=5a79318f-5107-41cd-95b9-ad588de13f52</zipfile_location>
+		<zipfile_datetime>20220423_095654</zipfile_datetime>
+		<zipfile_datetime_iso8601>2022-04-23T09:56:54Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2204907270</number>
+		<title>1W7RH840</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=c7b567ea-15af-4d21-8961-ad84f3cb70ef</zipfile_location>
+		<zipfile_datetime>20230413_063525</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-13T06:35:25Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>918630902</number>
+		<title>1W7EL030</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=5946d9d2-dbb9-467d-ad05-ad8a102f5601</zipfile_location>
+		<zipfile_datetime>20240227_063715</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:15Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3443563342</number>
+		<title>1W7MA370</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=2ab6e305-e3cb-4612-a1a1-ad980a416487</zipfile_location>
+		<zipfile_datetime>20210512_145219</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-12T14:52:19Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1236799569</number>
+		<title>1W7MA200</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=d3f1d7dc-08c3-40b4-a7c8-add640fb16f4</zipfile_location>
+		<zipfile_datetime>20210512_145216</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-12T14:52:16Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2638694671</number>
+		<title>3R7D0358</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=383a0374-708b-4b86-b385-add68c182d36</zipfile_location>
+		<zipfile_datetime>20230919_063548</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-09-19T06:35:48Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3014511489</number>
+		<title>3R7D0268</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=4a5de627-6ba9-44a2-88a5-adf2f2d8698b</zipfile_location>
+		<zipfile_datetime>20240613_063600</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-06-13T06:36:00Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4183143910</number>
+		<title>2P7D1366</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=3d3b5f98-fd77-4262-9b70-adf7a28eebf8</zipfile_location>
+		<zipfile_datetime>20230408_063539</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-08T06:35:39Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2419953660</number>
+		<title>1R7MA139</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=ab48f328-c429-48bf-9ee2-ae39dc380389</zipfile_location>
+		<zipfile_datetime>20210607_223237</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-06-07T22:32:37Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3184598807</number>
+		<title>1W7SO020</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=547dd5e9-d5f2-4ddc-af43-ae3c6af6ac25</zipfile_location>
+		<zipfile_datetime>20240227_063725</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:25Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2066377097</number>
+		<title>1R7WV007</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=5d1f2e72-d08b-4045-a1ab-aee10bc05518</zipfile_location>
+		<zipfile_datetime>20210903_143022</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T14:30:22Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1149806549</number>
+		<title>3B7D0380</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=9d595345-5173-41e5-9765-aee4e7c9e85f</zipfile_location>
+		<zipfile_datetime>20240829_063721</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-29T06:37:21Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3663172868</number>
+		<title>3R7D0255</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=53e676ce-a2d7-4c3b-a614-af05e7e364d1</zipfile_location>
+		<zipfile_datetime>20240613_063600</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-06-13T06:36:00Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3337682812</number>
+		<title>9D7EL780</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=0626b77e-4e1c-479f-ad76-af134dc11449</zipfile_location>
+		<zipfile_datetime>20230331_063528</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-03-31T06:35:28Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4121995036</number>
+		<title>1W7ML260</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=7a215894-5c71-443b-909d-af1ed4226409</zipfile_location>
+		<zipfile_datetime>20210908_095534</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:34Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1942642041</number>
+		<title>5C7D1409</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=2b9d69cf-7bd5-41b7-b04e-af70ad653758</zipfile_location>
+		<zipfile_datetime>20231109_102949</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-11-09T10:29:49Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4229286193</number>
+		<title>3R7D0980</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=4093acee-65a4-48db-81a1-af7910698814</zipfile_location>
+		<zipfile_datetime>20201209_103452</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-12-09T10:34:52Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1507219107</number>
+		<title>1W7UH060</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=cfab5e08-124d-4057-9e0a-af87a748f2aa</zipfile_location>
+		<zipfile_datetime>20240227_063725</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:25Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3069046228</number>
+		<title>1R7YM006</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=b2a283c8-dc95-4533-beaa-af9b8b0bba54</zipfile_location>
+		<zipfile_datetime>20210903_123729</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T12:37:29Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3929455763</number>
+		<title>1R7YM002</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=fb067f3a-9312-449e-b24a-afb40f97e1a0</zipfile_location>
+		<zipfile_datetime>20210903_123130</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T12:31:30Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3938649226</number>
+		<title>1H7D1570</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=2e206d7d-da63-4588-bfa0-b002ad25af2c</zipfile_location>
+		<zipfile_datetime>20230712_063523</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-07-12T06:35:23Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1400893802</number>
+		<title>BE8BK001</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=30c7e562-6d0d-4a03-9af0-b03ac933ffc0</zipfile_location>
+		<zipfile_datetime>20240826_161458</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-26T16:14:58Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2803305000</number>
+		<title>1W7RU000</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=e392723c-fb83-4208-9970-b0baa3f979f0</zipfile_location>
+		<zipfile_datetime>20210503_145617</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-03T14:56:17Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1056328811</number>
+		<title>1W7WDK02</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=9191bc6b-378b-4731-87a4-b0c118d73df0</zipfile_location>
+		<zipfile_datetime>20210503_145618</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-03T14:56:18Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3664182073</number>
+		<title>1W7RRS00</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=76fc8409-b2f9-4d73-b222-b156831ad951</zipfile_location>
+		<zipfile_datetime>20201022_171710</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-22T17:17:10Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>99436281</number>
+		<title>3R7D0802</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=c52fdab9-c828-4ef3-b0bc-b15699e69730</zipfile_location>
+		<zipfile_datetime>20240821_063622</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-21T06:36:22Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1548394810</number>
+		<title>2W7D1940</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=a433d98b-382e-4198-83f5-b183a36070fd</zipfile_location>
+		<zipfile_datetime>20230930_063711</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-09-30T06:37:11Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3793214815</number>
+		<title>1W7MO220</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=cf47c60a-1a31-422e-9512-b1a7f79ef3b5</zipfile_location>
+		<zipfile_datetime>20210908_095523</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:23Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1090614881</number>
+		<title>1W7EL290</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=c5a37955-f73a-452e-9e51-b1b42fe8e9a9</zipfile_location>
+		<zipfile_datetime>20240227_063720</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:20Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3612532543</number>
+		<title>4V5017DE</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=0c812389-6ec1-4cab-ab9c-b1db95a7acdf</zipfile_location>
+		<zipfile_datetime>20201022_171706</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-22T17:17:06Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3425065922</number>
+		<title>2P7D1222</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=d895c51c-99d6-4890-84f0-b1fe843b82e5</zipfile_location>
+		<zipfile_datetime>20230408_063537</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-08T06:35:37Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1758373028</number>
+		<title>8V8POA01</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=49e5b9b8-68fa-4b3f-8d80-b2536e2a47ff</zipfile_location>
+		<zipfile_datetime>20240412_090107</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-04-12T09:01:07Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>610050513</number>
+		<title>1H7TI440</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=6f9cab31-ffcb-49b6-883c-b261988fbea5</zipfile_location>
+		<zipfile_datetime>20211012_145459</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-10-12T14:54:59Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1391642065</number>
+		<title>1W7ML250</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=b58d2959-0d8a-4fd8-aec0-b2630aa5ec3f</zipfile_location>
+		<zipfile_datetime>20210908_095534</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:34Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1620546558</number>
+		<title>3R7D0032</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=24051c48-9edd-4563-8cf3-b2896e6181fd</zipfile_location>
+		<zipfile_datetime>20240613_063601</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-06-13T06:36:01Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2808078622</number>
+		<title>2WBD2060</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=0c839122-a255-4f3e-a5ca-b29bb90c3ea1</zipfile_location>
+		<zipfile_datetime>20230929_063649</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-09-29T06:36:49Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1891598686</number>
+		<title>1W7RH410</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=390974c9-cb8b-49f5-bbb7-b2c66641f515</zipfile_location>
+		<zipfile_datetime>20210914_095432</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-14T09:54:32Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3953262956</number>
+		<title>4V7SEI14</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=31bd5cc0-ce95-404d-9cbb-b2e0bffc4d92</zipfile_location>
+		<zipfile_datetime>20240409_164345</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-04-09T16:43:45Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3055644669</number>
+		<title>9D7EL767</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=aec0e602-3348-4583-bd14-b31b25ffbf5a</zipfile_location>
+		<zipfile_datetime>20230331_063528</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-03-31T06:35:28Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1503395119</number>
+		<title>1R7YM003</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=8ffe6cb9-c9d1-497e-951f-b31db50722ca</zipfile_location>
+		<zipfile_datetime>20210903_123220</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T12:32:20Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>320028628</number>
+		<title>9D7EL940</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=10375cb1-8e65-45ef-b1c4-b37129faa0ba</zipfile_location>
+		<zipfile_datetime>20230331_063530</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-03-31T06:35:30Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2343302064</number>
+		<title>1W7RH710</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=2125b4ce-8c8e-4a86-8280-b421fb3dd4e3</zipfile_location>
+		<zipfile_datetime>20210503_145644</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-03T14:56:44Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1413639018</number>
+		<title>4V7OIS07</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=b2af9584-ada4-409c-89ae-b43b751dff6b</zipfile_location>
+		<zipfile_datetime>20240409_171519</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-04-09T17:15:19Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1790038635</number>
+		<title>2R71007S</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=07ac0cfe-7d86-4626-8740-b4401afae1c8</zipfile_location>
+		<zipfile_datetime>20210126_112612</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-01-26T11:26:12Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1292309579</number>
+		<title>7V7ZEEK6</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=9af4def4-4866-41d2-abe3-b498dab0de10</zipfile_location>
+		<zipfile_datetime>20210701_111438</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:14:38Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1459164159</number>
+		<title>3R7D0791</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=2358ba08-51c4-4990-96af-b4dbeed9e058</zipfile_location>
+		<zipfile_datetime>20240821_063622</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-21T06:36:22Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3492014261</number>
+		<title>1W7DE003</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=b5bccd73-062c-4b0c-9e30-b4f115550c9e</zipfile_location>
+		<zipfile_datetime>20240227_063704</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:04Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3287424603</number>
+		<title>1W7EH350</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=27fa6cd3-8fc1-4311-b9b3-b51544a717f9</zipfile_location>
+		<zipfile_datetime>20240227_063724</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:24Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3008009824</number>
+		<title>3R7D0871</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=f046708d-e5d0-4fce-9791-b54eb832d3bc</zipfile_location>
+		<zipfile_datetime>20201209_103450</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-12-09T10:34:50Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3777665654</number>
+		<title>4V5GA030</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=a03fdf33-b74d-46d9-b3f1-b5876f2b1e49</zipfile_location>
+		<zipfile_datetime>20240408_143128</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-04-08T14:31:28Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>648795681</number>
+		<title>1W7RH300</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=dff555eb-8171-4dc0-80be-b592eb6faa3b</zipfile_location>
+		<zipfile_datetime>20201022_171712</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-22T17:17:12Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2593679336</number>
+		<title>3B7D0429</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=7c0a33e3-150f-4da4-b3ea-b599eeeaed0f</zipfile_location>
+		<zipfile_datetime>20240829_063721</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-29T06:37:21Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>180201144</number>
+		<title>3R7D0951</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=5c9cf8f8-729f-49f4-b08f-b5ad2e79ce99</zipfile_location>
+		<zipfile_datetime>20201209_103452</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-12-09T10:34:52Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>288636735</number>
+		<title>3R7D0933</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=0ddced4a-9961-4f76-9920-b5afffe5ee92</zipfile_location>
+		<zipfile_datetime>20201209_103451</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-12-09T10:34:51Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>704708445</number>
+		<title>2W7D2130</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=3aa34d50-85e3-49c5-acb9-b5c9259f284c</zipfile_location>
+		<zipfile_datetime>20230930_063735</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-09-30T06:37:35Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>792115899</number>
+		<title>1W7KTR00</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=b9df880d-9a4c-4c04-b644-b5efa3556f87</zipfile_location>
+		<zipfile_datetime>20210205_120412</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-02-05T12:04:12Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1253060015</number>
+		<title>1H7D1580</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=4cf4f55c-2513-4656-bbe1-b62bf6ed85e6</zipfile_location>
+		<zipfile_datetime>20230712_063524</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-07-12T06:35:24Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1239112405</number>
+		<title>7V7PLDU2</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=202e462a-8157-4b63-a7fb-b689c644d1bb</zipfile_location>
+		<zipfile_datetime>20210701_111435</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:14:35Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1470342119</number>
+		<title>1W7WE240</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=a5dfad4b-b8db-4e69-abe2-b6da0054cb24</zipfile_location>
+		<zipfile_datetime>20210908_095537</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:37Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3794141559</number>
+		<title>4V5003DE</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=44d0ffcf-1084-4ef2-a970-b77dda025107</zipfile_location>
+		<zipfile_datetime>20201022_171704</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-22T17:17:04Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2924859577</number>
+		<title>1W7SKL00</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=354f2548-691c-4c2e-ac84-b7ad44bef9e1</zipfile_location>
+		<zipfile_datetime>20210908_095536</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:36Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>351010426</number>
+		<title>2WBD1882</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=2af44a61-6f49-42b3-8215-b8918c4c4af5</zipfile_location>
+		<zipfile_datetime>20240830_063631</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-30T06:36:31Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1776312055</number>
+		<title>2P7D1311</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=0a6de14b-ee24-475d-89a2-b89ecc97f7ac</zipfile_location>
+		<zipfile_datetime>20230408_063538</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-08T06:35:38Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1653073921</number>
+		<title>2W7D1990</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=ec5cfffb-3d5d-4fa1-b7e4-b8ae7805e397</zipfile_location>
+		<zipfile_datetime>20230930_063658</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-09-30T06:36:58Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2810832769</number>
+		<title>1W7HO040</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=e6e2cc3b-34d8-42c9-95ed-b8b1e2ec8a7b</zipfile_location>
+		<zipfile_datetime>20201016_162828</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-16T16:28:28Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2298371984</number>
+		<title>1R7RM002</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=16fb0a31-0723-41ff-9edd-b8e0ce906172</zipfile_location>
+		<zipfile_datetime>20210903_153119</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T15:31:19Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1005189371</number>
+		<title>1R7BM000</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=927d6687-258e-47d5-8777-b8f6b30a268f</zipfile_location>
+		<zipfile_datetime>20210903_171136</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T17:11:36Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2441025213</number>
+		<title>7V7DURME</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=c1afcf80-9599-4f3b-947f-b91d17672348</zipfile_location>
+		<zipfile_datetime>20210701_110750</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:07:50Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1304815008</number>
+		<title>1R7ZW001</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=47a5e2f7-1d6c-46e8-bb31-b95bb6d5ab55</zipfile_location>
+		<zipfile_datetime>20210903_142123</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T14:21:23Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>32795103</number>
+		<title>1W7WE230</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=976acbd3-1ff2-445b-95f0-b973a00bdeb9</zipfile_location>
+		<zipfile_datetime>20210908_095537</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:37Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2965802849</number>
+		<title>7V7BZS06</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=9a460931-d47e-4184-bcc6-b98d4737d5bb</zipfile_location>
+		<zipfile_datetime>20210701_111123</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:11:23Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2382538448</number>
+		<title>1W7RH610</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=374bbade-a4a7-43ef-9ece-b9c67f4ca15d</zipfile_location>
+		<zipfile_datetime>20240227_063714</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:14Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4000190228</number>
+		<title>1W7RH520</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=8c7af55f-3886-45b0-b4a6-b9ca163cd15b</zipfile_location>
+		<zipfile_datetime>20240227_063711</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:11Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>893565138</number>
+		<title>3R7D0244</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=3430dc28-8d0e-4d8e-8afa-b9f25e7b78b6</zipfile_location>
+		<zipfile_datetime>20240613_063600</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-06-13T06:36:00Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>759959116</number>
+		<title>2R71011S</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=d802be76-c106-4034-b883-ba3f037f3b4a</zipfile_location>
+		<zipfile_datetime>20210126_112612</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-01-26T11:26:12Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>309933659</number>
+		<title>1H7TI400</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=54fc125c-b8e2-40a6-b754-ba6785aaf958</zipfile_location>
+		<zipfile_datetime>20211012_145458</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-10-12T14:54:58Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>237311991</number>
+		<title>2P7D1319</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=272efc65-d194-4a81-9ed5-ba7158cbc12b</zipfile_location>
+		<zipfile_datetime>20230408_063538</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-08T06:35:38Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1021836314</number>
+		<title>4V5MOS09</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=b75feef6-7a2c-4563-aec7-ba7ca23669ca</zipfile_location>
+		<zipfile_datetime>20221201_182018</zipfile_datetime>
+		<zipfile_datetime_iso8601>2022-12-01T18:20:18Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3132455259</number>
+		<title>1W7RH560</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=e49ad817-8da2-4abf-9cde-baf43052bc28</zipfile_location>
+		<zipfile_datetime>20240227_063712</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:12Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3056331147</number>
+		<title>1R7ZE016</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=2075efce-c55b-44ca-af56-bb2eefe19eb0</zipfile_location>
+		<zipfile_datetime>20210903_132755</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T13:27:55Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4105906302</number>
+		<title>1R7SP997</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=2f68e217-3ffa-4297-911a-bbdc97f08273</zipfile_location>
+		<zipfile_datetime>20210903_160510</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T16:05:10Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>222643456</number>
+		<title>1R7WK024</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=ae126a8a-de2b-498b-8dda-bbde2f5430f9</zipfile_location>
+		<zipfile_datetime>20210903_143942</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T14:39:42Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>690016529</number>
+		<title>1W7ELK30</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=be865cd3-ae4e-4c0a-b0c3-bbe4bce4e18a</zipfile_location>
+		<zipfile_datetime>20210512_145248</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-12T14:52:48Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4120011344</number>
+		<title>1W7EH370</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=bc917e0a-2bde-49da-94d5-bbf26649e008</zipfile_location>
+		<zipfile_datetime>20240227_063725</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:25Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2942734603</number>
+		<title>1W7RH740</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=b6b5fd6b-7185-42e8-9493-bc43eb521323</zipfile_location>
+		<zipfile_datetime>20240227_063714</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:14Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>265245815</number>
+		<title>1R7BO953</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=7f4d34cb-d54b-457f-ad40-bc95e325919a</zipfile_location>
+		<zipfile_datetime>20210903_154843</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T15:48:43Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>21384068</number>
+		<title>1R7YS931</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=d07b68d1-f84b-4250-8301-bc991398ad4d</zipfile_location>
+		<zipfile_datetime>20210903_121822</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T12:18:22Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2129301997</number>
+		<title>3B7D0547</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=1af36647-0ac2-4108-9f0f-bca9582dcbe9</zipfile_location>
+		<zipfile_datetime>20240829_063725</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-29T06:37:25Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1733646671</number>
+		<title>1W7OD550</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=56a3e4f2-42a3-41bb-a029-bca9df4c3ae2</zipfile_location>
+		<zipfile_datetime>20220611_063522</zipfile_datetime>
+		<zipfile_datetime_iso8601>2022-06-11T06:35:22Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2623121523</number>
+		<title>1W7EL560</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=760c35d0-93c9-4474-aef6-bcaf05a31d48</zipfile_location>
+		<zipfile_datetime>20230207_063519</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-02-07T06:35:19Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4000520455</number>
+		<title>7V7GENO3</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=aa029134-122c-4f78-bacb-bd3d803ed276</zipfile_location>
+		<zipfile_datetime>20210701_111431</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:14:31Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3405248727</number>
+		<title>1H7TI550</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=dfc3007e-02f5-4da1-ae22-bdc1bc8b8777</zipfile_location>
+		<zipfile_datetime>20211012_145501</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-10-12T14:55:01Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4052218408</number>
+		<title>7V7SRIJN</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=c2823063-24dd-4278-9d7b-be0e24b33e58</zipfile_location>
+		<zipfile_datetime>20210701_112119</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:21:19Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>954851869</number>
+		<title>2WBD2032</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=2280b86c-a9ac-4e2d-b033-be46b12ebadc</zipfile_location>
+		<zipfile_datetime>20230929_063649</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-09-29T06:36:49Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3886931212</number>
+		<title>1W7HO127</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=99339a79-2898-48dd-b815-be6fda4bfeaa</zipfile_location>
+		<zipfile_datetime>20201016_162828</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-16T16:28:28Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2287785851</number>
+		<title>1W7RH720</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=0a7bba14-972b-4a04-9b78-beaa60f145b7</zipfile_location>
+		<zipfile_datetime>20210503_145644</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-03T14:56:44Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2972058477</number>
+		<title>1R7YM004</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=0596bcdb-c192-47e9-9ed8-beb669e7f2e7</zipfile_location>
+		<zipfile_datetime>20210903_123300</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T12:33:00Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3048647209</number>
+		<title>1W7MO050</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=ea7146cf-cdda-4126-bfbe-bebf82d9ecbf</zipfile_location>
+		<zipfile_datetime>20210908_095515</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:15Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1550321431</number>
+		<title>1W7MA140</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=736c9481-a5ba-47fa-b5f5-bec816a174a9</zipfile_location>
+		<zipfile_datetime>20210512_145215</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-12T14:52:15Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2426523231</number>
+		<title>1W7MD120</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=7dd0ec18-003b-453d-a767-bee3094347e1</zipfile_location>
+		<zipfile_datetime>20210512_145224</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-12T14:52:24Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>142374862</number>
+		<title>1W7MD090</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=93e89cb1-77e9-49fc-8b0b-beeec4c56a3d</zipfile_location>
+		<zipfile_datetime>20210512_145224</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-12T14:52:24Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>787170750</number>
+		<title>2P7D1287</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=95771c28-8db8-4ac9-af46-bf0272e1ae12</zipfile_location>
+		<zipfile_datetime>20230408_063538</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-08T06:35:38Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4057606813</number>
+		<title>1R7WV114</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=f9d185d2-3b96-47ec-a840-bf9f56bd6e60</zipfile_location>
+		<zipfile_datetime>20210903_143422</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T14:34:22Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>795812227</number>
+		<title>1W7TEK30</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=64a0a8c1-a869-41dc-8525-bfaab3206a44</zipfile_location>
+		<zipfile_datetime>20230126_063503</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-01-26T06:35:03Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3864648782</number>
+		<title>2WBD2021</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=8b9dde55-f711-4d20-9697-bfaf4f890aa7</zipfile_location>
+		<zipfile_datetime>20240731_063653</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-07-31T06:36:53Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1950633585</number>
+		<title>1W7MA170</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=184b2b25-3f4a-416c-bf34-bffc4e61147c</zipfile_location>
+		<zipfile_datetime>20210512_145215</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-12T14:52:15Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3871341575</number>
+		<title>1W7EL110</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=7f2728da-810c-4572-940d-c00e49338b20</zipfile_location>
+		<zipfile_datetime>20240227_063717</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:17Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2354869442</number>
+		<title>1W7MD080</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=d8a75507-8e07-47dc-86d2-c0562857cd77</zipfile_location>
+		<zipfile_datetime>20210512_145222</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-12T14:52:22Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2167363924</number>
+		<title>3RB4DCC4</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=41dcffc4-3986-4bf9-89ec-c07c066366c5</zipfile_location>
+		<zipfile_datetime>20201016_162815</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-16T16:28:15Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2456307985</number>
+		<title>1W7D2290</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=42907ea4-dfcc-4dcc-a8f2-c09a20760725</zipfile_location>
+		<zipfile_datetime>20220611_063523</zipfile_datetime>
+		<zipfile_datetime_iso8601>2022-06-11T06:35:23Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1460293754</number>
+		<title>4V7SEI03</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=f8221c04-33c6-4438-be1e-c0f383904559</zipfile_location>
+		<zipfile_datetime>20240409_164412</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-04-09T16:44:12Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2303100397</number>
+		<title>2P7D1003</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=6a5a9152-c7dc-471d-bc73-c13442d4e91d</zipfile_location>
+		<zipfile_datetime>20230408_063534</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-08T06:35:34Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>34788702</number>
+		<title>1W7RH390</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=7546e412-1345-40ef-8d0e-c150b54bbf26</zipfile_location>
+		<zipfile_datetime>20240227_063709</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:09Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>833153928</number>
+		<title>3R7D0998</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=8cef4b5d-c744-4275-9a77-c1ef3d3562da</zipfile_location>
+		<zipfile_datetime>20201209_103452</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-12-09T10:34:52Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3944778244</number>
+		<title>4V7SEI10</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=a27154f1-b8d1-477b-b859-c25a12e7c2f6</zipfile_location>
+		<zipfile_datetime>20240409_164444</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-04-09T16:44:44Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2480402480</number>
+		<title>1W7MA050</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=2e9e0b0c-3172-4258-ac5a-c2724b6d9e04</zipfile_location>
+		<zipfile_datetime>20210512_145209</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-12T14:52:09Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3479709958</number>
+		<title>9D7EL755</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=8fc4f1eb-ed7c-4ddc-b06a-c300a5660e7d</zipfile_location>
+		<zipfile_datetime>20230331_063526</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-03-31T06:35:26Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3192522656</number>
+		<title>2P7D1232</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=29ce0176-2031-42b4-9e92-c3338555c5c2</zipfile_location>
+		<zipfile_datetime>20230419_063528</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-19T06:35:28Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1392780559</number>
+		<title>2WBDHALB</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=9af7c392-1575-40e9-bd59-c3ba3498c91b</zipfile_location>
+		<zipfile_datetime>20240731_063656</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-07-31T06:36:56Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>133770202</number>
+		<title>1W7RH360</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=c06eb454-fdf8-41a8-930c-c4090d217276</zipfile_location>
+		<zipfile_datetime>20240227_063709</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:09Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>122364649</number>
+		<title>5C7DR023</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=f9997ff7-b649-426d-a6aa-c4253fec480f</zipfile_location>
+		<zipfile_datetime>20210326_133016</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-03-26T13:30:16Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2643375564</number>
+		<title>1R7YM005</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=811b189d-1ad4-4e71-afd2-c4377ad1b75c</zipfile_location>
+		<zipfile_datetime>20210903_123347</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T12:33:47Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2557293916</number>
+		<title>9D7VL077</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=4f3cae56-1593-4c9a-909a-c4624bb26d36</zipfile_location>
+		<zipfile_datetime>20230331_063531</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-03-31T06:35:31Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1307790129</number>
+		<title>1R7WK001</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=8ae0ea6d-596e-4b8e-abb4-c4d6bf5a75f3</zipfile_location>
+		<zipfile_datetime>20210903_143552</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T14:35:52Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>66181725</number>
+		<title>3R7D0648</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=2c8c7110-b346-430a-9ade-c588be97760e</zipfile_location>
+		<zipfile_datetime>20240821_063617</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-21T06:36:17Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2251731713</number>
+		<title>7V7ALBK6</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=c3d705f5-e346-4583-bbaf-c5b62602ae64</zipfile_location>
+		<zipfile_datetime>20210701_110746</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:07:46Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2895752259</number>
+		<title>1W7WE210</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=1d548b6c-13d9-45e0-a9cb-c5f22b567252</zipfile_location>
+		<zipfile_datetime>20210908_095537</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:37Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>116656856</number>
+		<title>2WBD1950</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=54c767ef-1b20-4908-82cd-c5f8384969e0</zipfile_location>
+		<zipfile_datetime>20230930_063724</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-09-30T06:37:24Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3179288823</number>
+		<title>2P7D1075</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=af4a4cff-1fac-4ae6-9ba4-c61c8efd5239</zipfile_location>
+		<zipfile_datetime>20230408_063535</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-08T06:35:35Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1362969924</number>
+		<title>2P7D1104</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=a34fa224-12a0-4a00-b906-c628b0e9cbca</zipfile_location>
+		<zipfile_datetime>20230408_063535</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-08T06:35:35Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3825091113</number>
+		<title>1W7ML290</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=750ac1bb-07b9-49ff-8fc0-c71f779196fd</zipfile_location>
+		<zipfile_datetime>20210908_095535</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:35Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>556827316</number>
+		<title>7W7BOSC2</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=bf598cd4-fab3-4e4c-afd8-c73f57eb1ed7</zipfile_location>
+		<zipfile_datetime>20181018_211038</zipfile_datetime>
+		<zipfile_datetime_iso8601>2018-10-18T21:10:38Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3505020868</number>
+		<title>1W7SO040</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=1dc7aa93-0a4e-4d2c-9efa-c769ac41d51e</zipfile_location>
+		<zipfile_datetime>20240227_063725</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:25Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2129600569</number>
+		<title>2W7D2100</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=c4b29eed-0a5d-42fa-bd12-c7778f705bcd</zipfile_location>
+		<zipfile_datetime>20230930_063700</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-09-30T06:37:00Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1862341134</number>
+		<title>1H7TI630</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=f41cbfd2-c3c0-40c7-af42-c7a51f1db6fb</zipfile_location>
+		<zipfile_datetime>20211012_145505</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-10-12T14:55:05Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4085477436</number>
+		<title>3R7D0059</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=23609abb-1236-4638-9234-c7bfb0a1067d</zipfile_location>
+		<zipfile_datetime>20240824_063610</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-24T06:36:10Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4020146189</number>
+		<title>1W7RH310</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=18244f0d-0c66-417b-b67e-c8648e5f2874</zipfile_location>
+		<zipfile_datetime>20240227_063708</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:08Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1348209616</number>
+		<title>7V7ALBK1</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=decfc46b-c2c4-444b-9587-c898b760b93e</zipfile_location>
+		<zipfile_datetime>20240604_085844</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-06-04T08:58:44Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2954131827</number>
+		<title>1H7TI300</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=85445cf2-7497-454e-8762-c89b37186e8e</zipfile_location>
+		<zipfile_datetime>20211012_145455</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-10-12T14:54:55Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2362709904</number>
+		<title>1W7RH350</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=55024adb-c675-47f5-94e9-c8d49a74e8ca</zipfile_location>
+		<zipfile_datetime>20240227_063709</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:09Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2747019513</number>
+		<title>3R7D0942</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=94da591a-e9b6-4e78-959a-c914ac8bb7b7</zipfile_location>
+		<zipfile_datetime>20201209_103451</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-12-09T10:34:51Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1152041078</number>
+		<title>1W7RH580</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=016c0460-9b4d-42ff-8162-c977cdbef8b2</zipfile_location>
+		<zipfile_datetime>20240227_063713</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:13Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2575461106</number>
+		<title>4V5016DE</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=6822b20a-3cb0-4d20-845b-c9886b07b109</zipfile_location>
+		<zipfile_datetime>20201022_171706</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-22T17:17:06Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1012534120</number>
+		<title>1W7RH490</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=6132632c-f93a-47f6-8b98-c9985a42c23d</zipfile_location>
+		<zipfile_datetime>20240227_063711</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:11Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>131789583</number>
+		<title>3R7SFG07</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=47f64277-e666-4553-902e-c9d4efc70daa</zipfile_location>
+		<zipfile_datetime>20201016_162825</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-16T16:28:25Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1714749645</number>
+		<title>1W7EL270</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=ca56d5de-9e02-4f90-9248-ca05cc64e8fd</zipfile_location>
+		<zipfile_datetime>20240227_063720</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:20Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1585907798</number>
+		<title>1W7DE015</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=4596aea6-0ec1-4922-befd-ca141ef1b72e</zipfile_location>
+		<zipfile_datetime>20210503_145611</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-03T14:56:11Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2016481677</number>
+		<title>2P7TI017</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=0da84ab0-dc9d-43f6-ab1c-ca1b758366c7</zipfile_location>
+		<zipfile_datetime>20230408_063542</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-08T06:35:42Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2186388381</number>
+		<title>7V7RGENT</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=5a265433-f12e-4d90-b406-cabd3a7bea12</zipfile_location>
+		<zipfile_datetime>20210701_112117</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:21:17Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3585076674</number>
+		<title>3R7SFG04</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=5ef0af0d-c55d-4dc8-a632-cafa98faf6e9</zipfile_location>
+		<zipfile_datetime>20201016_162825</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-16T16:28:25Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2437184558</number>
+		<title>1W7TEK20</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=5fbe8b9f-7949-4e71-a23f-cb0d66d8954c</zipfile_location>
+		<zipfile_datetime>20230126_063503</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-01-26T06:35:03Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2086947168</number>
+		<title>8V8POA02</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=edd52d20-96f3-4f8f-96ac-cb3985dc2f82</zipfile_location>
+		<zipfile_datetime>20240412_090126</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-04-12T09:01:26Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1255027339</number>
+		<title>9D7EL735</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=5201f678-6107-4536-aaf0-cb52f15eb36b</zipfile_location>
+		<zipfile_datetime>20230331_063526</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-03-31T06:35:26Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3507975029</number>
+		<title>1W7SR080</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=e8bd5ec7-032e-48a3-9bb5-cb950626dc38</zipfile_location>
+		<zipfile_datetime>20210908_095526</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:26Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3539400435</number>
+		<title>1R7YM010</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=245bac36-8769-439d-b99c-cba4508bd76c</zipfile_location>
+		<zipfile_datetime>20210903_124050</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T12:40:50Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3624160673</number>
+		<title>9D7EL840</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=1638e577-22c1-45ba-a7ee-cc267aac50e1</zipfile_location>
+		<zipfile_datetime>20230331_063529</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-03-31T06:35:29Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>110617141</number>
+		<title>1W7MA100</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=12107719-6bc7-4abb-9b5c-cc374a01e598</zipfile_location>
+		<zipfile_datetime>20210512_145212</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-12T14:52:12Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2848778993</number>
+		<title>1W7MO010</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=a033619c-328d-4338-97f5-cc95aa87f9c2</zipfile_location>
+		<zipfile_datetime>20210908_095514</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:14Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4191358197</number>
+		<title>1R7LE944</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=fcd4657d-52b9-4075-a083-cc9a70772ceb</zipfile_location>
+		<zipfile_datetime>20210903_140404</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T14:04:04Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3846123184</number>
+		<title>3R7D0021</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=0fdf4bfa-fc32-4304-a7cb-ccad4402e78a</zipfile_location>
+		<zipfile_datetime>20240613_063601</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-06-13T06:36:01Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1362438738</number>
+		<title>1H7TI560</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=bedd886d-ed94-4865-bd6d-ccfbef09efea</zipfile_location>
+		<zipfile_datetime>20211012_145501</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-10-12T14:55:01Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2894728194</number>
+		<title>1W7EL390</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=d5c839f6-b29c-4713-ac4b-cd05e44b5445</zipfile_location>
+		<zipfile_datetime>20240227_063722</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:22Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1916877344</number>
+		<title>BE7EV002</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=b4318d14-c5ce-49de-8a02-cd09365f8865</zipfile_location>
+		<zipfile_datetime>20240820_113011</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-20T11:30:11Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4231316101</number>
+		<title>4V5GA070</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=c1dbdf54-c313-4189-889c-cd68afa3dd75</zipfile_location>
+		<zipfile_datetime>20240408_143337</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-04-08T14:33:37Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2206532792</number>
+		<title>9D7VL007</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=75f1ebbf-bcad-4afd-9d02-cd89208f0932</zipfile_location>
+		<zipfile_datetime>20230331_063530</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-03-31T06:35:30Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1862814255</number>
+		<title>2WBD2050</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=39d1a03c-4549-4db4-b269-cd9279289d7d</zipfile_location>
+		<zipfile_datetime>20230929_063649</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-09-29T06:36:49Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>298641383</number>
+		<title>7V7GENO6</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=6fc38272-7f2c-4d9d-bde5-cdd65602437c</zipfile_location>
+		<zipfile_datetime>20210701_111433</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:14:33Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3032041682</number>
+		<title>1W7UH140</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=12f42f63-d674-43da-8fc9-cdf0074bb72b</zipfile_location>
+		<zipfile_datetime>20230804_063500</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-08-04T06:35:00Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1013257150</number>
+		<title>9D7EL844</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=ca62f7d9-beb9-42be-ad28-cdfcd0ef523c</zipfile_location>
+		<zipfile_datetime>20230331_063529</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-03-31T06:35:29Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1535065332</number>
+		<title>5C7D1360</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=64377e2d-e67c-4c2a-b136-ce1add97c13d</zipfile_location>
+		<zipfile_datetime>20231109_102214</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-11-09T10:22:14Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2554043987</number>
+		<title>1W7EL350</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=2b5af8c8-1333-417d-9aab-ceb8cf4aa147</zipfile_location>
+		<zipfile_datetime>20240227_063721</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:21Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2984102546</number>
+		<title>1W7SL025</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=44d2a53f-fce9-482b-b2ae-cec2d517ba23</zipfile_location>
+		<zipfile_datetime>20231011_063505</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-10-11T06:35:05Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>480135573</number>
+		<title>1R7MA001</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=95835546-6084-4744-b8ed-cf1f7b0d93f7</zipfile_location>
+		<zipfile_datetime>20210607_102036</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-06-07T10:20:36Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2773944315</number>
+		<title>4V7SEI11</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=84b4c161-391d-43bc-b2ab-cf69dee69f49</zipfile_location>
+		<zipfile_datetime>20240409_164517</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-04-09T16:45:17Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1213557631</number>
+		<title>2P7D1277</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=4fa79441-2dda-451c-9d43-cf7abfe8308a</zipfile_location>
+		<zipfile_datetime>20230408_063537</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-08T06:35:37Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1976477189</number>
+		<title>1W7NE010</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=bbf7e028-a385-4492-8124-cf970e6ac570</zipfile_location>
+		<zipfile_datetime>20210914_095421</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-14T09:54:21Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>846136838</number>
+		<title>1W7MA210</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=a89337b4-4159-4080-a77c-cfa11bf8c51d</zipfile_location>
+		<zipfile_datetime>20210512_145216</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-12T14:52:16Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1757841357</number>
+		<title>1H7TI430</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=2714bdb7-69d4-441b-81a0-d000f0705b40</zipfile_location>
+		<zipfile_datetime>20211012_145458</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-10-12T14:54:58Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3191141424</number>
+		<title>3R7D1070</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=a03e6e49-33e6-4c3f-9cf0-d0430f327953</zipfile_location>
+		<zipfile_datetime>20201209_103453</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-12-09T10:34:53Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2590819415</number>
+		<title>1W7EL120</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=7e4894d2-4690-41b5-8294-d079dcf6b9c0</zipfile_location>
+		<zipfile_datetime>20240227_063717</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:17Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>605411730</number>
+		<title>2P7SA188</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=04f7ebd9-433c-433e-8c6b-d09772761575</zipfile_location>
+		<zipfile_datetime>20230413_063522</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-13T06:35:22Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1315287744</number>
+		<title>1R7AR035</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=3b074184-da36-44c4-892e-d0bb5d70ef19</zipfile_location>
+		<zipfile_datetime>20210903_145624</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T14:56:24Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3276423718</number>
+		<title>2W7D2180</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=bddda643-9c01-4711-92fd-d0c2c3cc3968</zipfile_location>
+		<zipfile_datetime>20240501_063821</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-05-01T06:38:21Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3816521030</number>
+		<title>3R7D0610</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=4adad46e-16c5-436a-9f9d-d0c7b2422fcf</zipfile_location>
+		<zipfile_datetime>20240821_063616</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-21T06:36:16Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1501955086</number>
+		<title>1R7EK012</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=8206d114-7bf7-4cad-8e68-d0de2c1fe1ce</zipfile_location>
+		<zipfile_datetime>20210903_151550</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T15:15:50Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3124680787</number>
+		<title>1W7SR030</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=aff727fe-a279-4bce-93e2-d1175880e832</zipfile_location>
+		<zipfile_datetime>20210908_095525</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:25Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1963050139</number>
+		<title>2P7D1213</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=344ce245-1c15-49c8-8636-d161784edff6</zipfile_location>
+		<zipfile_datetime>20230408_063537</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-08T06:35:37Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2414622898</number>
+		<title>1W7ELK50</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=d61a27b0-777e-41d6-ab61-d208115ba511</zipfile_location>
+		<zipfile_datetime>20210512_145249</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-12T14:52:49Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>372557042</number>
+		<title>1W7D2330</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=c46c8711-9561-47d0-b105-d245b58f2a3c</zipfile_location>
+		<zipfile_datetime>20220611_063523</zipfile_datetime>
+		<zipfile_datetime_iso8601>2022-06-11T06:35:23Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1179451014</number>
+		<title>1R7YS878</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=6a8f76c0-b42b-408d-bc87-d282f62eb67a</zipfile_location>
+		<zipfile_datetime>20210903_122048</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T12:20:48Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1087832550</number>
+		<title>2P7D1149</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=8e71587b-0bd5-4d18-b2bd-d2bbab1dacd3</zipfile_location>
+		<zipfile_datetime>20230408_063536</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-08T06:35:36Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3961445802</number>
+		<title>7V7RUP03</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=51a452aa-9d3b-4422-8e88-d2c9c06a30c8</zipfile_location>
+		<zipfile_datetime>20210701_112119</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:21:19Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1087456851</number>
+		<title>1W7NE040</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=960e6f79-c7b5-4af0-ad90-d2f20bb168cc</zipfile_location>
+		<zipfile_datetime>20210914_095422</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-14T09:54:22Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1440829905</number>
+		<title>1W7RH260</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=7c11be69-470b-420d-945d-d31036640601</zipfile_location>
+		<zipfile_datetime>20201022_171711</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-22T17:17:11Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4029758680</number>
+		<title>BE8OS001</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=92ed0e2e-640d-43b5-9d65-d344096ab336</zipfile_location>
+		<zipfile_datetime>20230808_100152</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-08-08T10:01:52Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2895346385</number>
+		<title>1W7ELK00</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=b22975dc-ead6-42f2-ae62-d3626e9cad03</zipfile_location>
+		<zipfile_datetime>20210512_145248</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-12T14:52:48Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2758826243</number>
+		<title>1H7TI240</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=a3fcf13a-888f-4f1b-b07f-d36964fee9cb</zipfile_location>
+		<zipfile_datetime>20211012_145453</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-10-12T14:54:53Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4122183425</number>
+		<title>1W7WE300</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=91e94852-cd40-4946-a95e-d36b4602a587</zipfile_location>
+		<zipfile_datetime>20210908_095539</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:39Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3261975229</number>
+		<title>1W7WE360</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=e3a7f6a4-a613-4c1c-a853-d37c3411acf1</zipfile_location>
+		<zipfile_datetime>20210908_095541</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:41Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1998864240</number>
+		<title>3R7D0956</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=54e1b0c5-7dd9-4766-b848-d3beb7b75096</zipfile_location>
+		<zipfile_datetime>20201209_103452</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-12-09T10:34:52Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>359518754</number>
+		<title>3B7D0559</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=9c6faf23-e556-4cd0-b7b7-d3c9cf975661</zipfile_location>
+		<zipfile_datetime>20240829_063725</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-29T06:37:25Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>185302304</number>
+		<title>1W7EL340</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=5aeb05de-948d-4add-8d9c-d3e1affc8908</zipfile_location>
+		<zipfile_datetime>20240227_063721</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:21Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>181723470</number>
+		<title>9DBEL735</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=08cec8c2-325e-4c52-818a-d3f1b9748883</zipfile_location>
+		<zipfile_datetime>20230331_063527</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-03-31T06:35:27Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1867247043</number>
+		<title>4V7SEI06</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=acb56a04-5691-4fc7-8930-d429c32381db</zipfile_location>
+		<zipfile_datetime>20240409_164546</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-04-09T16:45:46Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2910126584</number>
+		<title>1R7WA938</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=17f010d6-583c-48ca-b68c-d45b9a6e374d</zipfile_location>
+		<zipfile_datetime>20210903_145108</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T14:51:08Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3261850380</number>
+		<title>2P7D1142</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=f5961274-6903-415f-b6d2-d47550fceb05</zipfile_location>
+		<zipfile_datetime>20230408_063536</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-08T06:35:36Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3131940765</number>
+		<title>4V5018DE</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=86adf7d4-aea3-4e11-9dac-d4d01ddd4810</zipfile_location>
+		<zipfile_datetime>20201022_171706</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-22T17:17:06Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3158959349</number>
+		<title>1R7MA182</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=91343db8-3a87-457e-865f-d4d6ad38a2c1</zipfile_location>
+		<zipfile_datetime>20210903_115734</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T11:57:34Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>123364342</number>
+		<title>3R7D0189</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=6ba102a9-ce81-4842-a1cb-d5194c0bdf74</zipfile_location>
+		<zipfile_datetime>20240613_063558</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-06-13T06:35:58Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2235019425</number>
+		<title>1W7SO100</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=344fea56-4b4c-47d8-95f3-d5632e79e633</zipfile_location>
+		<zipfile_datetime>20220611_063526</zipfile_datetime>
+		<zipfile_datetime_iso8601>2022-06-11T06:35:26Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>824375071</number>
+		<title>1W7OD640</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=d92457fa-e49f-4960-89be-d6022b9f465e</zipfile_location>
+		<zipfile_datetime>20210205_120410</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-02-05T12:04:10Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>398656319</number>
+		<title>1W7MO140</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=fa7bcd15-f14e-4200-8757-d60e73c7fff7</zipfile_location>
+		<zipfile_datetime>20210908_095520</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:20Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2540366396</number>
+		<title>2W7D1960</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=a31917fe-246d-47b8-8b52-d615c09b5b71</zipfile_location>
+		<zipfile_datetime>20240529_063633</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-05-29T06:36:33Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1329827079</number>
+		<title>3R7D0782</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=dc3b8426-1c99-43d8-9b5b-d6188aad8b08</zipfile_location>
+		<zipfile_datetime>20240821_063621</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-21T06:36:21Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2965164041</number>
+		<title>1W7MA230</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=f00073b7-8941-45b4-ad55-d619cb3b77b4</zipfile_location>
+		<zipfile_datetime>20210512_145216</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-12T14:52:16Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2912811915</number>
+		<title>1H7D1640</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=484ae372-f1a6-40ba-b611-d61fc93511c3</zipfile_location>
+		<zipfile_datetime>20230712_063525</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-07-12T06:35:25Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1794501590</number>
+		<title>1W7ML040</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=56ab7f6b-3d46-43ff-b1e0-d68181a56737</zipfile_location>
+		<zipfile_datetime>20210908_095527</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:27Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>49650216</number>
+		<title>2R71033N</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=a2339a53-8047-4412-9b58-d69b9594eb61</zipfile_location>
+		<zipfile_datetime>20210126_112613</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-01-26T11:26:13Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4198446783</number>
+		<title>1H7TI660</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=b4754b70-20ae-457c-8ec7-d6a3c4bf736e</zipfile_location>
+		<zipfile_datetime>20211012_145506</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-10-12T14:55:06Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>432073904</number>
+		<title>7V7LEIE4</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=c141ae55-dddf-42ba-b138-d6ebc60fdccb</zipfile_location>
+		<zipfile_datetime>20210701_112114</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:21:14Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1637840909</number>
+		<title>5C7D1306</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=ae6cfc48-8ba5-4821-8581-d6f9efe74100</zipfile_location>
+		<zipfile_datetime>20231109_101358</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-11-09T10:13:58Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>121899002</number>
+		<title>2P7D1357</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=a9b77805-bca0-4f6c-b362-d71f3bf12f78</zipfile_location>
+		<zipfile_datetime>20230408_063538</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-08T06:35:38Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1123822882</number>
+		<title>1W7DE002</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=6bac24ec-52d9-4fcf-b495-d7320ad3b94e</zipfile_location>
+		<zipfile_datetime>20240227_063703</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:03Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1031818188</number>
+		<title>7W7ALEI2</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=ce0b834f-2919-421a-941e-d759db5a9a43</zipfile_location>
+		<zipfile_datetime>20181018_211038</zipfile_datetime>
+		<zipfile_datetime_iso8601>2018-10-18T21:10:38Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>192111237</number>
+		<title>3R7D0624</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=c256077d-f484-44ef-9f08-d761fcd73211</zipfile_location>
+		<zipfile_datetime>20240821_063616</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-21T06:36:16Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1131501417</number>
+		<title>4V5GA050</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=4ff807cd-66aa-4cd8-a767-d77287bbcb7d</zipfile_location>
+		<zipfile_datetime>20201022_171706</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-22T17:17:06Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1980978708</number>
+		<title>2D7D1737</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=080ccb0c-a5b0-473d-b976-d790c4d0f65f</zipfile_location>
+		<zipfile_datetime>20210908_095509</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:09Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3911527092</number>
+		<title>2W7D2040</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=5ec29b0a-c376-4167-a2d1-d7a567dadb6a</zipfile_location>
+		<zipfile_datetime>20230930_063659</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-09-30T06:36:59Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1176277871</number>
+		<title>1W7RH660</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=42563173-874b-45aa-89a2-d7a749ffe423</zipfile_location>
+		<zipfile_datetime>20210503_145644</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-03T14:56:44Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2173258670</number>
+		<title>5C7DR007</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=7b593ced-776b-428a-87c5-d7f9e9b7ee80</zipfile_location>
+		<zipfile_datetime>20210326_132558</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-03-26T13:25:58Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1204736207</number>
+		<title>1R7687XI</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=5b2ae91c-3989-48d1-8333-d7fdc8c8f46f</zipfile_location>
+		<zipfile_datetime>20210126_104617</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-01-26T10:46:17Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3731510133</number>
+		<title>7V7GENO1</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=f417c041-006a-4233-b437-d8192daab64c</zipfile_location>
+		<zipfile_datetime>20210701_111430</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:14:30Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3472050165</number>
+		<title>3B7D0418</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=765afa52-363e-44f0-821b-d8401c64a31f</zipfile_location>
+		<zipfile_datetime>20240829_063721</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-29T06:37:21Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1624328275</number>
+		<title>2WBD1940</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=2e369b35-654c-4d6a-a90a-d86ca7943271</zipfile_location>
+		<zipfile_datetime>20240403_063652</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-04-03T06:36:52Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1898343236</number>
+		<title>1W7NE180</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=2090567f-e063-4f83-bb14-d8bddde24c53</zipfile_location>
+		<zipfile_datetime>20210914_095429</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-14T09:54:29Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3163207645</number>
+		<title>1H7D1440</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=eea6b9f8-ce2b-4a0f-bc84-d920ebadf008</zipfile_location>
+		<zipfile_datetime>20230712_063521</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-07-12T06:35:21Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1524239212</number>
+		<title>1W7NE020</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=0137e13e-e9ca-4136-a6f9-d9354b35171f</zipfile_location>
+		<zipfile_datetime>20210914_095422</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-14T09:54:22Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4090037654</number>
+		<title>3R7DCC07</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=f6f14e31-15fd-442e-bd06-d94f58fa53af</zipfile_location>
+		<zipfile_datetime>20201016_162814</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-16T16:28:14Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2259855894</number>
+		<title>4V5SAO03</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=9ef59f00-eaf0-479e-ae9c-d9ca25a1b299</zipfile_location>
+		<zipfile_datetime>20201022_171712</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-22T17:17:12Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1737616084</number>
+		<title>1R7ZM046</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=880b6058-fd33-4ad4-b163-d9e51d07cf9f</zipfile_location>
+		<zipfile_datetime>20210903_142024</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T14:20:24Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>249702212</number>
+		<title>1R7WA899</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=99a8556d-caa2-4ac0-97e6-d9eb02823122</zipfile_location>
+		<zipfile_datetime>20210903_144557</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T14:45:57Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3302559020</number>
+		<title>2D7DK012</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=0c4e3689-f955-4e7c-b8b3-d9f2bc8c6d5c</zipfile_location>
+		<zipfile_datetime>20210908_095511</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:11Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>687041448</number>
+		<title>1W7UH070</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=c9f7b686-93b5-45de-985e-da029d0677d6</zipfile_location>
+		<zipfile_datetime>20230804_063459</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-08-04T06:34:59Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2030407480</number>
+		<title>4V7OIS02</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=3822ce99-e7e0-4baf-9ef4-da2c3f9f231d</zipfile_location>
+		<zipfile_datetime>20240409_171557</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-04-09T17:15:57Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3979765553</number>
+		<title>1W7D2350</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=d82af211-684a-4c06-a5ed-da47e57c7d52</zipfile_location>
+		<zipfile_datetime>20220611_063524</zipfile_datetime>
+		<zipfile_datetime_iso8601>2022-06-11T06:35:24Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>336507156</number>
+		<title>1W7EL020</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=73bc1aa2-2a37-4ab0-a515-dab949e624ab</zipfile_location>
+		<zipfile_datetime>20240227_063715</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:15Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1083482146</number>
+		<title>2WBD2011</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=8daf2ec2-8429-416c-a7a0-dae193621222</zipfile_location>
+		<zipfile_datetime>20240731_063651</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-07-31T06:36:51Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>430470069</number>
+		<title>2W7D2140</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=08a369bb-3f37-430d-9138-dae7f5fb1493</zipfile_location>
+		<zipfile_datetime>20240501_063819</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-05-01T06:38:19Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1165126345</number>
+		<title>1W7HO020</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=4f61aaf9-1b4d-4802-afd9-daedce3254be</zipfile_location>
+		<zipfile_datetime>20210205_120404</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-02-05T12:04:04Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1973890354</number>
+		<title>2P7D1133</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=34fd3307-6c3f-4429-8aa3-db00c02f0fe1</zipfile_location>
+		<zipfile_datetime>20230408_063536</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-08T06:35:36Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>639447586</number>
+		<title>1W7RH230</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=c74ce40c-2a7f-495a-a863-db58ed318f0a</zipfile_location>
+		<zipfile_datetime>20201022_171711</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-22T17:17:11Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1655145689</number>
+		<title>4V5013DE</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=bd78e92f-9a8c-4766-bc32-dbbd6455bec2</zipfile_location>
+		<zipfile_datetime>20201022_171705</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-22T17:17:05Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2045259462</number>
+		<title>1R7MA124</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=6e6d3a6c-d1fc-4b1b-8601-dbdc741d600b</zipfile_location>
+		<zipfile_datetime>20210607_223133</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-06-07T22:31:33Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>316076729</number>
+		<title>1W7MA260</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=c1111748-5b99-4b0a-8d12-dc6f0c638ef2</zipfile_location>
+		<zipfile_datetime>20210512_145217</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-12T14:52:17Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1947570358</number>
+		<title>7V7DTS02</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=88ec8417-9bfb-406c-90b4-dce049ceba8b</zipfile_location>
+		<zipfile_datetime>20210701_111257</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:12:57Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3655095287</number>
+		<title>7V7RUP02</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=776fbe3a-74e3-470d-9aee-dcf58b8bea63</zipfile_location>
+		<zipfile_datetime>20210701_110752</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:07:52Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2013490089</number>
+		<title>BE7BZ002</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=66b8122d-6f0a-40ba-9d4a-dd0a19cd1c89</zipfile_location>
+		<zipfile_datetime>20240605_124735</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-06-05T12:47:35Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3346180881</number>
+		<title>1W7NE120</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=5db3d77d-f467-46c3-871c-dd0f69a8b788</zipfile_location>
+		<zipfile_datetime>20210914_095427</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-14T09:54:27Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>172611502</number>
+		<title>3R7BM005</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=4d03c2a0-0824-45cf-b7b2-dd1746f41c61</zipfile_location>
+		<zipfile_datetime>20220326_095419</zipfile_datetime>
+		<zipfile_datetime_iso8601>2022-03-26T09:54:19Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1794205947</number>
+		<title>7V7ZWV04</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=74ed9f85-9521-4311-8f21-dd30601ce4c3</zipfile_location>
+		<zipfile_datetime>20210701_105058</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T10:50:58Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1146295501</number>
+		<title>1W7NE140</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=43aaa0d2-91eb-4c3f-a766-dd402d78f3ea</zipfile_location>
+		<zipfile_datetime>20210914_095428</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-14T09:54:28Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3546639887</number>
+		<title>BE7BZ001</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=0dd5da4d-81a1-4212-882b-dd4c1a473b1a</zipfile_location>
+		<zipfile_datetime>20240605_124712</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-06-05T12:47:12Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3615200534</number>
+		<title>3R7D0774</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=1ef815bb-f090-4edb-9118-dd8996d3f7f9</zipfile_location>
+		<zipfile_datetime>20240821_063621</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-21T06:36:21Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2962546566</number>
+		<title>2W7D2120</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=a2bc338d-9547-46fb-8f43-dd92a48eca84</zipfile_location>
+		<zipfile_datetime>20230930_063735</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-09-30T06:37:35Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4127277707</number>
+		<title>1W7RH860</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=e0bdb28a-3eeb-4a0e-b261-ddba7c0c8ae1</zipfile_location>
+		<zipfile_datetime>20230413_063525</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-13T06:35:25Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>475679934</number>
+		<title>1W7MA220</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=71c8e3b3-2ec4-4275-96ce-de6dff53c07a</zipfile_location>
+		<zipfile_datetime>20210512_145216</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-12T14:52:16Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2430063493</number>
+		<title>1R7YS945</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=b1cece57-2ca9-4914-b042-de8ffe3f4496</zipfile_location>
+		<zipfile_datetime>20210903_121658</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T12:16:58Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2213794108</number>
+		<title>2WBD2031</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=0ad609bd-a5ee-4c27-ac3e-dea00993c899</zipfile_location>
+		<zipfile_datetime>20240731_063655</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-07-31T06:36:55Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1710533356</number>
+		<title>2P7SA211</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=fd14799a-9b19-4180-927a-df11ac025e79</zipfile_location>
+		<zipfile_datetime>20230413_063523</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-13T06:35:23Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1213519044</number>
+		<title>2P7D0950</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=d1e7dacc-6aea-4fa5-999e-df5181757b74</zipfile_location>
+		<zipfile_datetime>20230408_063534</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-08T06:35:34Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>151236164</number>
+		<title>2P7D1398</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=3ce5cff8-7af6-427a-b7bc-df6aae8b7266</zipfile_location>
+		<zipfile_datetime>20230408_063539</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-08T06:35:39Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1168804194</number>
+		<title>1W7ML230</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=342bf427-dd98-4d2f-ba02-df7e166f0e65</zipfile_location>
+		<zipfile_datetime>20210908_095532</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:32Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1468910796</number>
+		<title>2P7D1156</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=ce592f2e-664e-4388-b23f-dfe4bebb9271</zipfile_location>
+		<zipfile_datetime>20230408_063536</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-08T06:35:36Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1345372801</number>
+		<title>7V7KGETE</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=cff85098-7749-462a-a378-e0607f44f4a2</zipfile_location>
+		<zipfile_datetime>20210701_111434</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:14:34Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3007546352</number>
+		<title>2WBDHFRE</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=7abb4177-9b48-40f5-8ba0-e0df14760fe2</zipfile_location>
+		<zipfile_datetime>20240830_063635</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-30T06:36:35Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1282274766</number>
+		<title>1W7MD100</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=8d3a0013-dda6-4b9a-bdc7-e0f95a255885</zipfile_location>
+		<zipfile_datetime>20210512_145224</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-12T14:52:24Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3234122732</number>
+		<title>2P7D1433</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=d1e6a78b-80ee-4340-a18c-e14f78fde9b0</zipfile_location>
+		<zipfile_datetime>20230408_063539</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-08T06:35:39Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3116080209</number>
+		<title>7V7BOSC2</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=0838f425-b274-443d-a09c-e19afb4bc0db</zipfile_location>
+		<zipfile_datetime>20210701_111119</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:11:19Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2767488286</number>
+		<title>7V7DTS05</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=75e93a5e-d1fa-401d-b2a4-e19ec42cb808</zipfile_location>
+		<zipfile_datetime>20210701_111300</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:13:00Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2396379969</number>
+		<title>1H7TI580</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=b6a0d7d2-c077-4f69-b677-e1a4616a9c0e</zipfile_location>
+		<zipfile_datetime>20211012_145503</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-10-12T14:55:03Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3380950704</number>
+		<title>1H7D1600</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=cd924a76-7405-4fdc-b547-e2dd03f669ba</zipfile_location>
+		<zipfile_datetime>20230712_063524</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-07-12T06:35:24Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2836930711</number>
+		<title>2WBD2170</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=4b6084a9-db2f-49ad-98c7-e2dfa6a9ed10</zipfile_location>
+		<zipfile_datetime>20240131_063609</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-01-31T06:36:09Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3270083523</number>
+		<title>2W7D1980</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=96d6bab0-6589-4790-9c22-e2f438258ea9</zipfile_location>
+		<zipfile_datetime>20240529_063634</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-05-29T06:36:34Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1666338381</number>
+		<title>1W7RH530</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=9b765cea-0db0-4048-bb55-e300c2c71cd2</zipfile_location>
+		<zipfile_datetime>20240227_063712</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:12Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2182946159</number>
+		<title>2WBD1891</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=5d42fb9b-bd76-4a32-87ff-e31cf0ca5ac4</zipfile_location>
+		<zipfile_datetime>20240830_063632</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-30T06:36:32Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2611907732</number>
+		<title>1W7HO117</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=b5dd231d-68ea-4064-9fac-e323d3168758</zipfile_location>
+		<zipfile_datetime>20201016_162828</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-16T16:28:28Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3033713997</number>
+		<title>1R7NI963</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=6c34b37c-8d2c-4a65-a512-e3352fb91efe</zipfile_location>
+		<zipfile_datetime>20210903_170333</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T17:03:33Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2685600748</number>
+		<title>1W7HOH01</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=834d58a5-76d6-4c2f-90c0-e33958d497a7</zipfile_location>
+		<zipfile_datetime>20230804_063459</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-08-04T06:34:59Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2222951998</number>
+		<title>1W7SO050</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=fe02320e-ad92-4be1-a7d8-e34aa0855b56</zipfile_location>
+		<zipfile_datetime>20221103_063448</zipfile_datetime>
+		<zipfile_datetime_iso8601>2022-11-03T06:34:48Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2418177000</number>
+		<title>1H7D1710</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=d53a0ddf-6359-45b3-beef-e36ad8a53cfb</zipfile_location>
+		<zipfile_datetime>20230712_063526</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-07-12T06:35:26Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2053504518</number>
+		<title>1W7EH330</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=250e58eb-848c-4535-a4fe-e37c51f46069</zipfile_location>
+		<zipfile_datetime>20240227_063724</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:24Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1949985150</number>
+		<title>3R7D0637</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=4753a02e-f6e0-4fc7-804d-e3a3f74d75bc</zipfile_location>
+		<zipfile_datetime>20240821_063617</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-21T06:36:17Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2140149218</number>
+		<title>1W7EL440</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=4599b8ee-d779-4faa-b852-e3f7706c11bc</zipfile_location>
+		<zipfile_datetime>20240227_063723</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:23Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2789411467</number>
+		<title>1W7DE010</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=c1dcc796-2925-4212-b186-e41805ecf464</zipfile_location>
+		<zipfile_datetime>20210908_095513</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:13Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1652124334</number>
+		<title>4V5SAO02</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=3aa7e86e-2eba-473a-ba0e-e4346a61b0d8</zipfile_location>
+		<zipfile_datetime>20201022_171712</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-22T17:17:12Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3950888928</number>
+		<title>4V5SAO04</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=2dc6167a-8186-45d1-a5c9-e43b883b914a</zipfile_location>
+		<zipfile_datetime>20201022_171712</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-22T17:17:12Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1895193520</number>
+		<title>3R7SFG01</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=075d480f-a195-460f-8087-e446a0d3941b</zipfile_location>
+		<zipfile_datetime>20201016_162825</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-16T16:28:25Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1054045441</number>
+		<title>1W7SR090</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=b03f8513-1f1c-4f0c-aed4-e448998e1fb9</zipfile_location>
+		<zipfile_datetime>20210908_095526</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:26Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1990634108</number>
+		<title>1R7MA027</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=299b09a6-fc71-4f84-ba83-e45f27aba396</zipfile_location>
+		<zipfile_datetime>20210607_103929</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-06-07T10:39:29Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>867038974</number>
+		<title>1R7OM977</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=fba89e99-436b-4cff-85b8-e475e01dc43e</zipfile_location>
+		<zipfile_datetime>20210903_151732</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T15:17:32Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3569471452</number>
+		<title>3R7DCC06</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=938351bf-5540-4619-8dcf-e48a4d297c05</zipfile_location>
+		<zipfile_datetime>20220423_095653</zipfile_datetime>
+		<zipfile_datetime_iso8601>2022-04-23T09:56:53Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1827342286</number>
+		<title>2P7D1388</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=5bc53292-3322-4d28-adc2-e4c43972470c</zipfile_location>
+		<zipfile_datetime>20230408_063539</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-08T06:35:39Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2793838049</number>
+		<title>7W7BOSC4</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=67acf1fb-bf00-412d-8dad-e4d2c7cc196d</zipfile_location>
+		<zipfile_datetime>20181018_211038</zipfile_datetime>
+		<zipfile_datetime_iso8601>2018-10-18T21:10:38Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1306807775</number>
+		<title>5C7D1433</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=9f4e68bd-0321-4272-9d47-e50931da9e71</zipfile_location>
+		<zipfile_datetime>20231109_110418</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-11-09T11:04:18Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1221302191</number>
+		<title>1W7ML120</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=d304baae-45b4-45d6-8988-e533f574a572</zipfile_location>
+		<zipfile_datetime>20210908_095529</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:29Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1639107934</number>
+		<title>3B7D0593</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=2ad39c63-29c8-4f92-9e07-e54137b7c369</zipfile_location>
+		<zipfile_datetime>20240829_063726</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-29T06:37:26Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>640697444</number>
+		<title>1R7WK052</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=d241c3ac-9548-46d9-9ff6-e5a4822e62b7</zipfile_location>
+		<zipfile_datetime>20210903_144111</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T14:41:11Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1491217290</number>
+		<title>2P7D0942</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=32d05517-502f-42c0-b48f-e5a8876b6b9d</zipfile_location>
+		<zipfile_datetime>20230408_063534</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-08T06:35:34Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>805522554</number>
+		<title>1W7EL500</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=81593be3-22b8-4f8d-a3e8-e5c456a2a373</zipfile_location>
+		<zipfile_datetime>20230207_063519</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-02-07T06:35:19Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3552915514</number>
+		<title>1W7ELK20</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=d8bf5428-2b24-4310-a38e-e6047fb3d6a5</zipfile_location>
+		<zipfile_datetime>20210512_145248</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-12T14:52:48Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1284923878</number>
+		<title>2WBD2014</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=2e216b84-7d49-44d6-9e44-e61dc103f310</zipfile_location>
+		<zipfile_datetime>20240731_063652</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-07-31T06:36:52Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>843145427</number>
+		<title>4V5GA060</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=a87ed929-e671-490b-b4b4-e68dbcb43a1d</zipfile_location>
+		<zipfile_datetime>20201022_171706</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-22T17:17:06Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2442451654</number>
+		<title>2P7SA169</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=e0b36960-dd40-42a1-a343-e6b7cea7d356</zipfile_location>
+		<zipfile_datetime>20230413_063522</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-13T06:35:22Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>23881002</number>
+		<title>1W7EL180</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=35ccbdd1-113d-475e-9e0e-e6c8acfbf3b8</zipfile_location>
+		<zipfile_datetime>20240227_063718</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:18Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3353075425</number>
+		<title>1W7MA020</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=32e58c19-449a-43be-a304-e749288c84d4</zipfile_location>
+		<zipfile_datetime>20210512_145209</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-12T14:52:09Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>668913394</number>
+		<title>2WBD1902</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=aa640caa-1cc1-4f8d-af69-e792fb0dee6b</zipfile_location>
+		<zipfile_datetime>20240614_063720</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-06-14T06:37:20Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>992640929</number>
+		<title>3R7D0036</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=b37d70de-cab3-4be5-b828-e7d8a5752ba9</zipfile_location>
+		<zipfile_datetime>20240613_063602</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-06-13T06:36:02Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1759950520</number>
+		<title>3R7D0927</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=aab42f6b-b53c-482a-b4c1-e80b3864b685</zipfile_location>
+		<zipfile_datetime>20201209_103451</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-12-09T10:34:51Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3822286270</number>
+		<title>1H7D1650</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=5cbf7db8-ac85-442c-a890-e8574fe1f0ea</zipfile_location>
+		<zipfile_datetime>20230712_063525</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-07-12T06:35:25Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>320939287</number>
+		<title>1W7WE310</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=77f961b1-6888-47fb-8c90-e877b8207d53</zipfile_location>
+		<zipfile_datetime>20210908_095539</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:39Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2985826170</number>
+		<title>1W7MD040</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=baf14f2e-0c2f-4726-be47-e893cad1aa60</zipfile_location>
+		<zipfile_datetime>20210512_145220</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-12T14:52:20Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>885126001</number>
+		<title>2WBD1904</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=3af28a10-79be-4551-afa3-e8a01e555cab</zipfile_location>
+		<zipfile_datetime>20230930_063720</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-09-30T06:37:20Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>61429488</number>
+		<title>5C7D1398</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=85b77c20-2a51-44da-86c9-e8a9f8140d81</zipfile_location>
+		<zipfile_datetime>20231109_102800</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-11-09T10:28:00Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>401969731</number>
+		<title>3R7D0877</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=5015a5a3-9ab6-4c58-a9dd-e9077b531058</zipfile_location>
+		<zipfile_datetime>20201209_103450</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-12-09T10:34:50Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1189459741</number>
+		<title>1H7D1480</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=d908b9b8-6a74-44ae-a7d9-e944adda5ba6</zipfile_location>
+		<zipfile_datetime>20230712_063522</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-07-12T06:35:22Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>978020113</number>
+		<title>1W7SO001</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=8104adeb-4b7c-4d84-9f5c-e952c2dd0dd9</zipfile_location>
+		<zipfile_datetime>20221103_063448</zipfile_datetime>
+		<zipfile_datetime_iso8601>2022-11-03T06:34:48Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1737243696</number>
+		<title>3R7BM004</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=b3e6a043-96c8-4065-8f01-e956f55d4096</zipfile_location>
+		<zipfile_datetime>20220326_095418</zipfile_datetime>
+		<zipfile_datetime_iso8601>2022-03-26T09:54:18Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>170407797</number>
+		<title>1R7HD002</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=9cb6cce5-2966-42b8-b94c-e988f60e2156</zipfile_location>
+		<zipfile_datetime>20210903_142601</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T14:26:01Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3029309001</number>
+		<title>1W7ML180</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=6d3a8b5d-6aae-4431-9cd8-e9da2c8f61c8</zipfile_location>
+		<zipfile_datetime>20210908_095531</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:31Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1102308332</number>
+		<title>7V7BOHE1</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=ca635f30-9a97-437e-8894-ea0c6a2bf795</zipfile_location>
+		<zipfile_datetime>20210701_111254</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:12:54Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>770633221</number>
+		<title>1H7TI370</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=05d5e551-44ec-46f3-9357-ea2c713520b1</zipfile_location>
+		<zipfile_datetime>20211012_145457</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-10-12T14:54:57Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>967869476</number>
+		<title>3R7D0237</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=f7b77698-a435-4886-a08b-ea47ccdf67b4</zipfile_location>
+		<zipfile_datetime>20240613_063559</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-06-13T06:35:59Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1441084534</number>
+		<title>1R7YM013</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=e556ff38-2f1a-4f3d-87e0-ea51334e8725</zipfile_location>
+		<zipfile_datetime>20210903_124328</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T12:43:28Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>219100827</number>
+		<title>1W7D2260</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=7da9f449-8f5c-406d-b742-eaae97118d25</zipfile_location>
+		<zipfile_datetime>20220611_063523</zipfile_datetime>
+		<zipfile_datetime_iso8601>2022-06-11T06:35:23Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4291995076</number>
+		<title>7V7ZEEK5</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=e3ff9650-39e5-42dc-b30f-eac845aa06a0</zipfile_location>
+		<zipfile_datetime>20210701_111438</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:14:38Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>547159298</number>
+		<title>1H7TI310</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=6937ec22-fb66-412d-abc7-eb5ef42f25fb</zipfile_location>
+		<zipfile_datetime>20211012_145455</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-10-12T14:54:55Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>496933863</number>
+		<title>1W7RH670</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=003024d5-c63c-4574-a25d-eb9ed2db388f</zipfile_location>
+		<zipfile_datetime>20210503_145644</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-03T14:56:44Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4114523143</number>
+		<title>4V7SEI16</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=a3f17218-96a7-4c27-889f-ec21cf3d5576</zipfile_location>
+		<zipfile_datetime>20240409_164618</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-04-09T16:46:18Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3856488346</number>
+		<title>1W7OD690</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=540654e7-cbe5-4cd5-987e-ecc1e38c1611</zipfile_location>
+		<zipfile_datetime>20210205_120411</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-02-05T12:04:11Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3385772430</number>
+		<title>1W7PHV03</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=d4a00985-976c-4c54-b278-ed1de82a222d</zipfile_location>
+		<zipfile_datetime>20230804_063501</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-08-04T06:35:01Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2802813106</number>
+		<title>1H7D1737</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=24b6a28f-a1ec-4ee4-95ae-ed2aadb9696f</zipfile_location>
+		<zipfile_datetime>20230712_063526</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-07-12T06:35:26Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2286594956</number>
+		<title>2WBDK017</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=f03c119f-bb56-446b-a9e4-edb347e528ad</zipfile_location>
+		<zipfile_datetime>20230929_063654</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-09-29T06:36:54Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1682789061</number>
+		<title>1W5EL005</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=3cb69983-f597-4337-86f0-edbc670d68ce</zipfile_location>
+		<zipfile_datetime>20211001_174315</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-10-01T17:43:15Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>405788395</number>
+		<title>1W7MD070</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=3a53ca3c-4a60-4f9a-bb7f-ee749fcfc95f</zipfile_location>
+		<zipfile_datetime>20210512_145220</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-12T14:52:20Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>753477332</number>
+		<title>BE8ZEE01</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=7912dafb-8b17-4f5c-ba1a-ee85527807ce</zipfile_location>
+		<zipfile_datetime>20231127_161748</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-11-27T16:17:48Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2134100078</number>
+		<title>7W7BOSC3</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=1b345126-4d43-4003-b803-ee9f3267a4bd</zipfile_location>
+		<zipfile_datetime>20181018_211038</zipfile_datetime>
+		<zipfile_datetime_iso8601>2018-10-18T21:10:38Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>746815540</number>
+		<title>1W7MD150</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=c30e8e71-031d-477b-bc93-eea099af0009</zipfile_location>
+		<zipfile_datetime>20210512_145225</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-12T14:52:25Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3659623778</number>
+		<title>2P7SA138</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=889b0f79-b2bf-4947-8394-eec8425fbee5</zipfile_location>
+		<zipfile_datetime>20230413_063522</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-13T06:35:22Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3614233038</number>
+		<title>1R7WZ003</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=e17f777a-a207-4299-a7d3-eed50325602b</zipfile_location>
+		<zipfile_datetime>20210903_105436</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T10:54:36Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2622393082</number>
+		<title>1W7NE200</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=60e6ca13-5122-4c15-ad7b-ef320160053c</zipfile_location>
+		<zipfile_datetime>20210914_095429</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-14T09:54:29Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>20107306</number>
+		<title>1R7ZE042</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=2b13625c-4005-45db-8d55-ef597f249cb7</zipfile_location>
+		<zipfile_datetime>20210903_133032</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T13:30:32Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2661747602</number>
+		<title>1H7TI330</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=019437cb-c75a-415e-95e6-ef5b08815733</zipfile_location>
+		<zipfile_datetime>20211012_145456</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-10-12T14:54:56Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>222558653</number>
+		<title>5C7D1419</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=ca2e4bfd-fa91-40ab-a5ff-ef5fd5b07f14</zipfile_location>
+		<zipfile_datetime>20231109_103032</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-11-09T10:30:32Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>724409616</number>
+		<title>3B7D0500</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=3262ba26-376a-454b-af29-efab6d650340</zipfile_location>
+		<zipfile_datetime>20240829_063723</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-29T06:37:23Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1634451698</number>
+		<title>1W7RH380</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=f273f9a1-4ff9-4251-b647-effdf885c959</zipfile_location>
+		<zipfile_datetime>20240227_063709</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:09Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3249772721</number>
+		<title>1W7RHK04</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=b6f8e6cd-14c5-4429-ba28-f01b8dae11d3</zipfile_location>
+		<zipfile_datetime>20230413_063525</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-13T06:35:25Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2913722873</number>
+		<title>1H7D1450</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=ecaedde4-6b4d-4de9-a4d4-f05fcc1abba1</zipfile_location>
+		<zipfile_datetime>20230712_063521</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-07-12T06:35:21Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2202548209</number>
+		<title>1W7RH790</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=f049e576-02ef-4114-9c08-f08bd8985b8d</zipfile_location>
+		<zipfile_datetime>20240227_063714</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:14Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3577752328</number>
+		<title>1R7NR879</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=0f6a72fa-cac1-4ba0-af2f-f095f1c14e59</zipfile_location>
+		<zipfile_datetime>20210903_152029</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T15:20:29Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1055627980</number>
+		<title>2WBD2202</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=8e8eb179-dfa2-45b4-bb66-f0b186698733</zipfile_location>
+		<zipfile_datetime>20230930_063710</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-09-30T06:37:10Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1483578570</number>
+		<title>3RB4DCC2</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=1b254bc7-e03e-4494-9953-f0c3e50d71e2</zipfile_location>
+		<zipfile_datetime>20201016_162815</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-16T16:28:15Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2525273999</number>
+		<title>1W7DE018</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=a529cc5e-d7ba-40f5-9e1b-f0f3b9d0da6e</zipfile_location>
+		<zipfile_datetime>20230413_063524</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-13T06:35:24Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1809560362</number>
+		<title>3R7D0052</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=ca9ab598-f664-4a72-bdca-f10681e225aa</zipfile_location>
+		<zipfile_datetime>20240824_063610</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-24T06:36:10Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>649765311</number>
+		<title>1W7RHK02</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=3925a9c2-2cd2-4651-b121-f10995a5cc16</zipfile_location>
+		<zipfile_datetime>20210503_145617</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-03T14:56:17Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1197543196</number>
+		<title>4V5SAO07</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=75a8d730-5c8a-4bb2-815e-f14b35dbcabc</zipfile_location>
+		<zipfile_datetime>20201022_171712</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-22T17:17:12Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2285110978</number>
+		<title>7V7BZS04</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=718394fa-c32e-4180-a707-f1621981d0c7</zipfile_location>
+		<zipfile_datetime>20210701_111122</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:11:22Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1518277741</number>
+		<title>4V7SEI09</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=e8ba46f6-a287-4cf0-a247-f1783e6f7779</zipfile_location>
+		<zipfile_datetime>20240409_164647</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-04-09T16:46:47Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2811908753</number>
+		<title>1W7SR050</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=b78e94b6-202f-4766-ba8b-f1825e758e72</zipfile_location>
+		<zipfile_datetime>20210908_095525</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:25Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2499308496</number>
+		<title>3R7BM003</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=5d9d17d1-7a18-447d-aa1f-f1b0cc469221</zipfile_location>
+		<zipfile_datetime>20220326_095418</zipfile_datetime>
+		<zipfile_datetime_iso8601>2022-03-26T09:54:18Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2637599409</number>
+		<title>1W7OD680</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=dfd51030-f340-4c8a-a86a-f1b0eb1e7cde</zipfile_location>
+		<zipfile_datetime>20210205_120411</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-02-05T12:04:11Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1050118429</number>
+		<title>1W7UH100</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=95181e2a-8513-4a7e-8363-f1bf07fdd0a7</zipfile_location>
+		<zipfile_datetime>20230804_063459</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-08-04T06:34:59Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3624748286</number>
+		<title>1W7MD010</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=b34e7cdc-7332-4a1b-ae96-f202b291ccb8</zipfile_location>
+		<zipfile_datetime>20210512_145219</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-12T14:52:19Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3039580369</number>
+		<title>2P7D1164</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=3038c4be-9311-4605-bc46-f22bf943c72e</zipfile_location>
+		<zipfile_datetime>20230408_063536</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-08T06:35:36Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>303618696</number>
+		<title>1R7BR866</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=84bc01f5-1eac-4026-8b38-f22ccab6b77d</zipfile_location>
+		<zipfile_datetime>20210903_155654</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T15:56:54Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2071193193</number>
+		<title>1H7D1510</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=23fd2dbc-b488-4be6-8b6f-f28e00427713</zipfile_location>
+		<zipfile_datetime>20230712_063522</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-07-12T06:35:22Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1244657013</number>
+		<title>1W7MA120</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=034094e3-602c-4de8-8f5d-f29f093472d5</zipfile_location>
+		<zipfile_datetime>20210512_145214</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-12T14:52:14Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>908847092</number>
+		<title>3RB4DCC3</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=4e8ca689-354f-4ca0-ab01-f2c5410a1e85</zipfile_location>
+		<zipfile_datetime>20201016_162815</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-16T16:28:15Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>653250571</number>
+		<title>9DBEL730</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=242ac424-2f6b-4681-b7d1-f3976b6e7209</zipfile_location>
+		<zipfile_datetime>20230331_063527</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-03-31T06:35:27Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>200024183</number>
+		<title>1W7SL005</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=5a48a228-727e-44b5-a90a-f39b72950d5a</zipfile_location>
+		<zipfile_datetime>20231011_063505</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-10-11T06:35:05Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2154234154</number>
+		<title>1W7DE019</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=76962abf-30df-42b2-a911-f3c04eadcb3b</zipfile_location>
+		<zipfile_datetime>20230413_063524</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-13T06:35:24Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1199298722</number>
+		<title>1H7D1800</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=fc41a4ff-d959-4fd6-8110-f3dbbfde1e5f</zipfile_location>
+		<zipfile_datetime>20230712_063528</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-07-12T06:35:28Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2460752069</number>
+		<title>2WBD2022</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=b4e516ec-2a4d-46e1-acaa-f408981f0025</zipfile_location>
+		<zipfile_datetime>20240731_063653</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-07-31T06:36:53Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>159196148</number>
+		<title>3R7D0670</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=ad203a99-3707-45cc-b9e8-f40f3b60629c</zipfile_location>
+		<zipfile_datetime>20240821_063617</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-21T06:36:17Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>534170883</number>
+		<title>1W7MO000</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=db526d17-d59f-4d81-abb1-f41803f2fbb0</zipfile_location>
+		<zipfile_datetime>20210908_095514</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:14Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3464920151</number>
+		<title>1H7D1680</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=4cd7c112-5223-4740-a4ee-f437b1338764</zipfile_location>
+		<zipfile_datetime>20230712_063525</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-07-12T06:35:25Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1889112873</number>
+		<title>1W7ML130</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=fb5ecce0-d9fc-4804-a471-f445553aa63d</zipfile_location>
+		<zipfile_datetime>20210908_095529</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:29Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4247643668</number>
+		<title>2WBD1885</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=30821261-0cd6-48a2-8fe5-f44d20799dd7</zipfile_location>
+		<zipfile_datetime>20240614_063717</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-06-14T06:37:17Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3212343873</number>
+		<title>1R7BM228</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=3bec059e-3745-4f7a-974a-f47544cd294f</zipfile_location>
+		<zipfile_datetime>20210903_154205</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T15:42:05Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1511567102</number>
+		<title>2W7D2060</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=6790b1d2-a4a7-43e0-a1da-f4cc96f9a827</zipfile_location>
+		<zipfile_datetime>20230930_063638</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-09-30T06:36:38Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3743936032</number>
+		<title>3R7D1044</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=03ec1757-7ce9-4a17-b15e-f4d1972a67d7</zipfile_location>
+		<zipfile_datetime>20201209_103453</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-12-09T10:34:53Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3361285750</number>
+		<title>1H7D1791</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=91db7bd1-3099-4836-868e-f507160a56a7</zipfile_location>
+		<zipfile_datetime>20230712_063527</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-07-12T06:35:27Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>165859952</number>
+		<title>1W7KK000</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=5f0dfb4e-2826-4aa0-9772-f522fc124e76</zipfile_location>
+		<zipfile_datetime>20230413_063524</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-13T06:35:24Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>565229456</number>
+		<title>1W7UH110</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=0bad77c9-374c-48a3-941f-f58f88f3ecbb</zipfile_location>
+		<zipfile_datetime>20230804_063459</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-08-04T06:34:59Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3606936177</number>
+		<title>2R71022N</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=5c905637-abcf-4374-a0e4-f5bbfb631836</zipfile_location>
+		<zipfile_datetime>20210126_112612</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-01-26T11:26:12Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2152962186</number>
+		<title>3B7D0409</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=aa38f782-dfc3-43e3-af06-f6132cb4dcb6</zipfile_location>
+		<zipfile_datetime>20240829_063721</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-08-29T06:37:21Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>612937646</number>
+		<title>1W7EL580</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=fb3edd60-3c57-437d-9a39-f67230599ee2</zipfile_location>
+		<zipfile_datetime>20230207_063520</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-02-07T06:35:20Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3836450491</number>
+		<title>7V7BEDIJ</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=768d7657-d4cc-448d-8b86-f68bc7022860</zipfile_location>
+		<zipfile_datetime>20210701_110749</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:07:49Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>530903004</number>
+		<title>1H7D1620</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=879de163-520e-4c2c-897a-f6b8feb418f0</zipfile_location>
+		<zipfile_datetime>20230712_063524</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-07-12T06:35:24Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3266002840</number>
+		<title>2P7D1257</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=17d28616-4c39-4c00-9c6c-f6bda05d54c4</zipfile_location>
+		<zipfile_datetime>20230408_063537</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-08T06:35:37Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2306456706</number>
+		<title>2WBD1906</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=22d0ae15-1e5a-4a4b-af14-f6d35b36f16f</zipfile_location>
+		<zipfile_datetime>20240614_063723</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-06-14T06:37:23Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1780837280</number>
+		<title>1H7D1752</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=8c18f09f-f7d5-4ee5-9ea8-f713dc81d298</zipfile_location>
+		<zipfile_datetime>20230712_063527</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-07-12T06:35:27Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2637983096</number>
+		<title>3R7D0964</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=3e53270d-b137-43f6-b3d4-f71720200779</zipfile_location>
+		<zipfile_datetime>20201209_103452</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-12-09T10:34:52Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2806593354</number>
+		<title>7V7RUP01</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=19e369ca-5f93-4875-a548-f7473ef8d5fd</zipfile_location>
+		<zipfile_datetime>20210701_112118</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:21:18Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>431003633</number>
+		<title>4V5SAO13</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=57100d8c-23ab-4698-b68f-f765dee61833</zipfile_location>
+		<zipfile_datetime>20201022_171713</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-22T17:17:13Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1614228449</number>
+		<title>1W7UH050</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=92dae421-93c6-4241-8012-f78d58fe3689</zipfile_location>
+		<zipfile_datetime>20231011_063507</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-10-11T06:35:07Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3515580728</number>
+		<title>4V7OIS03</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=39074d89-24e9-4809-b6d7-f7bf60cce854</zipfile_location>
+		<zipfile_datetime>20240409_171627</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-04-09T17:16:27Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3540083621</number>
+		<title>9D7VL047</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=b35a297f-19c0-4e0c-a08c-f809bf22f00d</zipfile_location>
+		<zipfile_datetime>20230331_063531</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-03-31T06:35:31Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2456571513</number>
+		<title>1W7OD700</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=ef81ace7-874d-4b53-8b00-f81a84197903</zipfile_location>
+		<zipfile_datetime>20210205_120411</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-02-05T12:04:11Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3707187284</number>
+		<title>1R7WA911</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=6b768445-0a8c-40d0-968b-f88b3dfb7db2</zipfile_location>
+		<zipfile_datetime>20210903_144640</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T14:46:40Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1185965610</number>
+		<title>1H7D1500</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=b7838903-692a-478b-863f-f8979c5dc24a</zipfile_location>
+		<zipfile_datetime>20230712_063522</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-07-12T06:35:22Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2430000276</number>
+		<title>4V5SAO15</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=fd578191-3fe0-4be7-9f32-f8b40c4ebb46</zipfile_location>
+		<zipfile_datetime>20201022_171713</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-22T17:17:13Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>926526177</number>
+		<title>1W7ELK10</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=9507ba5c-0874-48fb-91ca-f8dabbaf9f8e</zipfile_location>
+		<zipfile_datetime>20210512_145248</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-12T14:52:48Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>136403062</number>
+		<title>1W7EH340</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=eef19651-f9ea-436e-98f9-f8f9076c7b1d</zipfile_location>
+		<zipfile_datetime>20240227_063724</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:24Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2015310500</number>
+		<title>2P7TI120</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=e63b347f-5eae-4c17-839d-f92b47071533</zipfile_location>
+		<zipfile_datetime>20230408_063543</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-04-08T06:35:43Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2744429041</number>
+		<title>1W7ML100</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=d0e2dfc1-55b7-4b7b-9295-f959ae1abf8d</zipfile_location>
+		<zipfile_datetime>20210908_095529</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:29Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2784864682</number>
+		<title>1H7SZD20</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=bf5189bb-c19e-495e-afb5-f96e6603639a</zipfile_location>
+		<zipfile_datetime>20201016_162819</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-16T16:28:19Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3716871167</number>
+		<title>2D7D1723</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=adf711d6-d88e-49c9-afeb-f980e00cb5a0</zipfile_location>
+		<zipfile_datetime>20210908_095509</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:09Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2640031570</number>
+		<title>1R7YM011</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=2e452ab7-0dff-4717-b44b-f98e77d3e80a</zipfile_location>
+		<zipfile_datetime>20210903_124138</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T12:41:38Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>57226246</number>
+		<title>1W7RH420</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=0aa4fae4-92fb-46f7-8b1c-f9d641ec9ad9</zipfile_location>
+		<zipfile_datetime>20240227_063709</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:09Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>23089267</number>
+		<title>4V7SEI13</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=6d9db0d8-8611-4221-bdcf-fa32df4c5c96</zipfile_location>
+		<zipfile_datetime>20240409_164855</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-04-09T16:48:55Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3793791809</number>
+		<title>1R7WK040</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=d6fb717b-b2fb-41b8-9f14-fa34757e9d89</zipfile_location>
+		<zipfile_datetime>20210903_144028</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T14:40:28Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2520468406</number>
+		<title>3R7D0342</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=1366950d-615a-4c93-a98e-fa610e9dddeb</zipfile_location>
+		<zipfile_datetime>20230919_063547</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-09-19T06:35:47Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2681959807</number>
+		<title>1W7SR060</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=48bf1aa1-d8dc-48e0-a93d-fa8408447bcc</zipfile_location>
+		<zipfile_datetime>20210908_095525</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:25Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2234338202</number>
+		<title>1W7DE001</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=68eb5036-d0cd-4e22-a2d2-fa9e9d236c5d</zipfile_location>
+		<zipfile_datetime>20240227_063703</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:03Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4159201275</number>
+		<title>3R7D0010</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=c2f966a1-8904-4b01-a53b-fafe8c08e699</zipfile_location>
+		<zipfile_datetime>20240613_063601</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-06-13T06:36:01Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2471888538</number>
+		<title>1W7RH250</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=18b27060-00f7-43ca-9b69-faff92453c31</zipfile_location>
+		<zipfile_datetime>20201022_171711</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-22T17:17:11Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3793294752</number>
+		<title>1W7EL600</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=9634c365-0bc3-45f0-99ce-fb1a63e00790</zipfile_location>
+		<zipfile_datetime>20230207_063520</zipfile_datetime>
+		<zipfile_datetime_iso8601>2023-02-07T06:35:20Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>501974309</number>
+		<title>1W7OD542</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=5215dee7-f218-448a-9452-fb2572141107</zipfile_location>
+		<zipfile_datetime>20210205_120407</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-02-05T12:04:07Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2456025321</number>
+		<title>1H7TI640</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=fcd279ef-6daf-4e95-be47-fbd264c9b457</zipfile_location>
+		<zipfile_datetime>20211012_145505</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-10-12T14:55:05Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4212696303</number>
+		<title>1W7RH440</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=3fef5e28-522f-48db-bf99-fc0bd4e036d6</zipfile_location>
+		<zipfile_datetime>20240227_063710</zipfile_datetime>
+		<zipfile_datetime_iso8601>2024-02-27T06:37:10Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3056694431</number>
+		<title>1R7MA068</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=ab3fda81-df20-4a53-a35a-fc21580a7906</zipfile_location>
+		<zipfile_datetime>20210607_222406</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-06-07T22:24:06Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2112702043</number>
+		<title>1W7WE320</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=5a475e52-fcca-4832-b871-fc4d25e86723</zipfile_location>
+		<zipfile_datetime>20210908_095540</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-08T09:55:40Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1368491184</number>
+		<title>1R7RM001</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=64c0304a-49db-4e87-9de8-fc537afdce7d</zipfile_location>
+		<zipfile_datetime>20210903_153205</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T15:32:05Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>281342697</number>
+		<title>1R7WV010</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=dc99d5f2-1f64-4a57-9ffb-fd11393dd903</zipfile_location>
+		<zipfile_datetime>20210903_143150</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T14:31:50Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>2274132534</number>
+		<title>7V7BZS02</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=2718a86d-127c-44d1-9c21-fdd4cff8b9c4</zipfile_location>
+		<zipfile_datetime>20210701_111121</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-07-01T11:11:21Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1465509611</number>
+		<title>1W7HO030</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=d2455c34-2a08-42cf-9b6e-fe3af9f00b3f</zipfile_location>
+		<zipfile_datetime>20201016_162828</zipfile_datetime>
+		<zipfile_datetime_iso8601>2020-10-16T16:28:28Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>1642318319</number>
+		<title>1R7YS956</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=29d0611d-b9aa-4521-bcbe-fe815fbb365d</zipfile_location>
+		<zipfile_datetime>20210903_121538</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T12:15:38Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3804561170</number>
+		<title>1W7OD570</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=bc7106cf-f6f6-420a-ac4b-fef9d7fd5b8b</zipfile_location>
+		<zipfile_datetime>20210205_120407</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-02-05T12:04:07Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>4172238052</number>
+		<title>1W7MD130</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=3e0414a6-c856-48a3-88a6-ff1f008f0245</zipfile_location>
+		<zipfile_datetime>20210512_145225</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-05-12T14:52:25Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>3444230583</number>
+		<title>1H7TI230</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=6cea622d-eeac-42be-ac0e-ff715a8d2781</zipfile_location>
+		<zipfile_datetime>20211012_145453</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-10-12T14:54:53Z</zipfile_datetime_iso8601>
+	</chart>
+	<chart>
+		<number>612690817</number>
+		<title>1R7IJ020</title>
+		<format>Sailing Chart, International Chart</format>
+		<zipfile_location>https://www.eurisportal.eu/AWFIENC/api/IENC/DownloadIENCMap?mapID=98723b49-a6ff-43c4-9c1e-ffd7c035ed5e</zipfile_location>
+		<zipfile_datetime>20210903_155920</zipfile_datetime>
+		<zipfile_datetime_iso8601>2021-09-03T15:59:20Z</zipfile_datetime_iso8601>
+	</chart>
+</RncProductCatalogChartCatalogs>


### PR DESCRIPTION
Add EURIS IENC catalog file to collection.

A Python script for generating the catalog can be found at https://github.com/chartcatalogs/scripts/pull/6.